### PR TITLE
Support for File (OpenAIFile)

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -24,7 +24,7 @@ reqwest-eventsource = "0.4.0"
 serde = { version = "1.0.148", features = ["derive", "rc"] }
 serde_json = "1.0.87"
 thiserror = "1.0.37"
-tokio = { version = "1.22.0", features = ["fs"] }
+tokio = { version = "1.22.0", features = ["fs", "macros"] }
 tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["codec", "io-util"] }
 

--- a/async-openai/README.md
+++ b/async-openai/README.md
@@ -25,7 +25,8 @@
   - [x] Edit
   - [ ] Embeddings
   - [ ] Fine-Tuning
-  - [x] Image (Generation/Edit/Variation)
+  - [x] Files (List, Upload, Delete, Retrieve, Retrieve Content)
+  - [x] Image (Generation, Edit, Variation)
   - [x] Moderation
 
 *Being a young project there are rough edges*

--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -84,6 +84,20 @@ impl Client {
         self.process_response(response).await
     }
 
+    /// Make a DELETE request to {path} and deserialize the response body
+    pub(crate) async fn delete<O>(&self, path: &str) -> Result<O, OpenAIError>
+    where
+        O: DeserializeOwned,
+    {
+        let response = reqwest::Client::new()
+            .delete(format!("{}{path}", self.api_base()))
+            .bearer_auth(self.api_key())
+            .send()
+            .await?;
+
+        self.process_response(response).await
+    }
+
     /// Make a POST request to {path} and deserialize the response body
     pub(crate) async fn post<I, O>(&self, path: &str, request: I) -> Result<O, OpenAIError>
     where

--- a/async-openai/src/download.rs
+++ b/async-openai/src/download.rs
@@ -22,13 +22,13 @@ fn create_paths<P: AsRef<Path>>(url: &Url, base_dir: P) -> (PathBuf, PathBuf) {
 }
 
 pub(crate) async fn download_url<P: AsRef<Path>>(url: &str, dir: P) -> Result<(), OpenAIError> {
-    let parsed_url = Url::parse(url).map_err(|e| OpenAIError::ImageSaveError(e.to_string()))?;
+    let parsed_url = Url::parse(url).map_err(|e| OpenAIError::FileSaveError(e.to_string()))?;
     let response = reqwest::get(url)
         .await
-        .map_err(|e| OpenAIError::ImageSaveError(e.to_string()))?;
+        .map_err(|e| OpenAIError::FileSaveError(e.to_string()))?;
 
     if !response.status().is_success() {
-        return Err(OpenAIError::ImageSaveError(format!(
+        return Err(OpenAIError::FileSaveError(format!(
             "couldn't download file (status: {})",
             response.status()
         )));
@@ -38,17 +38,17 @@ pub(crate) async fn download_url<P: AsRef<Path>>(url: &str, dir: P) -> Result<()
 
     tokio::fs::create_dir_all(dir)
         .await
-        .map_err(|e| OpenAIError::ImageSaveError(e.to_string()))?;
+        .map_err(|e| OpenAIError::FileSaveError(e.to_string()))?;
 
     tokio::fs::write(
         file_path,
         response
             .bytes()
             .await
-            .map_err(|e| OpenAIError::ImageSaveError(e.to_string()))?,
+            .map_err(|e| OpenAIError::FileSaveError(e.to_string()))?,
     )
     .await
-    .map_err(|e| OpenAIError::ImageSaveError(e.to_string()))?;
+    .map_err(|e| OpenAIError::FileSaveError(e.to_string()))?;
 
     Ok(())
 }
@@ -66,10 +66,10 @@ pub(crate) async fn save_b64<P: AsRef<Path>>(b64: &str, dir: P) -> Result<(), Op
 
     tokio::fs::write(
         path,
-        base64::decode(b64).map_err(|e| OpenAIError::ImageSaveError(e.to_string()))?,
+        base64::decode(b64).map_err(|e| OpenAIError::FileSaveError(e.to_string()))?,
     )
     .await
-    .map_err(|e| OpenAIError::ImageSaveError(e.to_string()))?;
+    .map_err(|e| OpenAIError::FileSaveError(e.to_string()))?;
 
     Ok(())
 }

--- a/async-openai/src/error.rs
+++ b/async-openai/src/error.rs
@@ -12,12 +12,12 @@ pub enum OpenAIError {
     /// Error when a response cannot be deserialized into a Rust type
     #[error("failed to deserialize api response: {0}")]
     JSONDeserialize(serde_json::Error),
-    /// Error on the client side when saving image to file system
-    #[error("failed to save image: {0}")]
-    ImageSaveError(String),
-    /// Error on the client side when reading image from file system
-    #[error("failed to read image: {0}")]
-    ImageReadError(String),
+    /// Error on the client side when saving file to file system
+    #[error("failed to save file: {0}")]
+    FileSaveError(String),
+    /// Error on the client side when reading file from file system
+    #[error("failed to read file: {0}")]
+    FileReadError(String),
     /// Error when trying to stream completions SSE
     #[error("stream failed: {0}")]
     StreamError(String),

--- a/async-openai/src/file.rs
+++ b/async-openai/src/file.rs
@@ -1,0 +1,109 @@
+use crate::{
+    error::OpenAIError,
+    types::{CreateFileRequest, DeleteFileResponse, ListFilesResponse, OpenAIFile},
+    util::create_file_part,
+    Client,
+};
+
+/// Files are used to upload documents that can be used with features like [Fine-tuning](https://beta.openai.com/docs/api-reference/fine-tunes).
+pub struct File;
+
+impl File {
+    /// Upload a file that contains document(s) to be used across various endpoints/features. Currently, the size of all the files uploaded by one organization can be up to 1 GB. Please contact us if you need to increase the storage limit.
+    pub async fn create(
+        client: &Client,
+        request: CreateFileRequest,
+    ) -> Result<OpenAIFile, OpenAIError> {
+        let file_part = create_file_part(&request.file.path).await?;
+        let form = reqwest::multipart::Form::new()
+            .part("file", file_part)
+            .text("purpose", request.purpose);
+        client.post_form("/files", form).await
+    }
+
+    /// Returns a list of files that belong to the user's organization.
+    pub async fn list(client: &Client) -> Result<ListFilesResponse, OpenAIError> {
+        client.get("/files").await
+    }
+
+    /// Returns information about a specific file.
+    pub async fn retrieve(client: &Client, file_id: &str) -> Result<OpenAIFile, OpenAIError> {
+        client.get(format!("/files/{file_id}").as_str()).await
+    }
+
+    /// Delete a file.
+    pub async fn delete(client: &Client, file_id: &str) -> Result<DeleteFileResponse, OpenAIError> {
+        client.delete(format!("/files/{file_id}").as_str()).await
+    }
+
+    /// Returns the contents of the specified file
+    pub async fn retrieve_content(client: &Client, file_id: &str) -> Result<String, OpenAIError> {
+        client
+            .get(format!("/files/{file_id}/content").as_str())
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        types::{CreateFileRequest, FileInput},
+        Client,
+    };
+
+    use super::File;
+    #[tokio::test]
+    async fn test_file_mod() {
+        let test_file_path = "/tmp/test.jsonl";
+        let contents = "{\"prompt\": \"<prompt text>\", \"completion\": \"<ideal generated text>\"}
+{\"prompt\": \"<prompt text>\", \"completion\": \"<ideal generated text>\"}";
+        tokio::fs::write(test_file_path, contents).await.unwrap();
+
+        let client = Client::new();
+
+        let request = CreateFileRequest {
+            file: FileInput::new(test_file_path),
+            purpose: "fine-tune".to_owned(),
+        };
+        let openai_file = File::create(&client, request).await.unwrap();
+
+        assert_eq!(openai_file.bytes, 135);
+        assert_eq!(openai_file.filename, "test.jsonl");
+        assert_eq!(openai_file.purpose, "fine-tune");
+        //assert_eq!(openai_file.status, Some("processed".to_owned())); // uploaded or processed
+
+        //println!("CREATE: \n{:#?}", openai_file);
+
+        let list_files = File::list(&client).await.unwrap();
+
+        assert_eq!(list_files.data.into_iter().last().unwrap(), openai_file);
+
+        //println!("LIST: \n{:#?}", list_files);
+
+        let retrieve_file = File::retrieve(&client, &openai_file.id).await.unwrap();
+
+        // println!("RETRIEVE: \n{:#?}", retrieve_file);
+
+        assert_eq!(retrieve_file, openai_file);
+
+        /*
+        // "To help mitigate abuse, downloading of fine-tune training files is disabled for free accounts."
+        let retrieved_contents = File::retrieve_content(&client, &openai_file.id)
+            .await
+            .unwrap();
+
+        //println!("CONTENTS:\n{}", retrieve_contents);
+
+        assert_eq!(contents, retrieved_contents);
+        */
+
+        // Sleep to prevent "File is still processing. Check back later."
+        tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+        let delete_response = File::delete(&client, &openai_file.id).await.unwrap();
+
+        // println!("DELETE: \n{:#?}", delete_response);
+
+        assert_eq!(openai_file.id, delete_response.id);
+        assert_eq!(delete_response.deleted, true);
+    }
+}

--- a/async-openai/src/image.rs
+++ b/async-openai/src/image.rs
@@ -1,12 +1,9 @@
-use reqwest::Body;
-use tokio_util::codec::{BytesCodec, FramedRead};
-
 use crate::{
     error::OpenAIError,
     types::{
-        CreateImageEditRequest, CreateImageRequest, CreateImageVariationRequest, ImageInput,
-        ImageResponse,
+        CreateImageEditRequest, CreateImageRequest, CreateImageVariationRequest, ImageResponse,
     },
+    util::create_file_part,
     Client,
 };
 
@@ -24,49 +21,13 @@ impl Image {
         client.post("/images/generations", request).await
     }
 
-    pub(crate) async fn file_stream_body(image_input: &ImageInput) -> Result<Body, OpenAIError> {
-        let file = tokio::fs::File::open(image_input.path.as_path())
-            .await
-            .map_err(|e| OpenAIError::ImageReadError(e.to_string()))?;
-        let stream = FramedRead::new(file, BytesCodec::new());
-        let body = Body::wrap_stream(stream);
-        Ok(body)
-    }
-
-    /// Creates the part for the given image file for multipart upload.
-    pub(crate) async fn create_part(
-        image_input: &ImageInput,
-    ) -> Result<reqwest::multipart::Part, OpenAIError> {
-        let image_file_name = image_input
-            .path
-            .as_path()
-            .file_name()
-            .ok_or_else(|| {
-                OpenAIError::ImageReadError(format!(
-                    "cannot extract file name from {:#?}",
-                    image_input.path
-                ))
-            })?
-            .to_str()
-            .unwrap()
-            .to_string();
-
-        let image_part =
-            reqwest::multipart::Part::stream(Image::file_stream_body(image_input).await?)
-                .file_name(image_file_name)
-                .mime_str("application/octet-stream")
-                .unwrap();
-
-        Ok(image_part)
-    }
-
     /// Creates an edited or extended image given an original image and a prompt.
     pub async fn create_edit(
         client: &Client,
         request: CreateImageEditRequest,
     ) -> Result<ImageResponse, OpenAIError> {
-        let image_part = Image::create_part(&request.image).await?;
-        let mask_part = Image::create_part(&request.mask).await?;
+        let image_part = create_file_part(&request.image.path).await?;
+        let mask_part = create_file_part(&request.mask.path).await?;
 
         let mut form = reqwest::multipart::Form::new()
             .part("image", image_part)
@@ -100,7 +61,7 @@ impl Image {
         client: &Client,
         request: CreateImageVariationRequest,
     ) -> Result<ImageResponse, OpenAIError> {
-        let image_part = Image::create_part(&request.image).await?;
+        let image_part = create_file_part(&request.image.path).await?;
 
         let mut form = reqwest::multipart::Form::new().part("image", image_part);
 

--- a/async-openai/src/lib.rs
+++ b/async-openai/src/lib.rs
@@ -43,15 +43,18 @@ mod completion;
 mod download;
 mod edit;
 pub mod error;
+mod file;
 mod image;
 mod model;
 mod moderation;
 pub mod types;
+mod util;
 
 pub use client::Client;
 pub use client::API_BASE;
 pub use completion::Completion;
 pub use edit::Edit;
+pub use file::File;
 pub use image::Image;
 pub use model::Models;
 pub use moderation::Moderation;

--- a/async-openai/src/util.rs
+++ b/async-openai/src/util.rs
@@ -1,0 +1,40 @@
+use std::path::Path;
+
+use reqwest::Body;
+use tokio_util::codec::{BytesCodec, FramedRead};
+
+use crate::error::OpenAIError;
+
+pub(crate) async fn file_stream_body<P: AsRef<Path>>(path: P) -> Result<Body, OpenAIError> {
+    let file = tokio::fs::File::open(path.as_ref())
+        .await
+        .map_err(|e| OpenAIError::FileReadError(e.to_string()))?;
+    let stream = FramedRead::new(file, BytesCodec::new());
+    let body = Body::wrap_stream(stream);
+    Ok(body)
+}
+
+/// Creates the part for the given image file for multipart upload.
+pub(crate) async fn create_file_part<P: AsRef<Path>>(
+    path: P,
+) -> Result<reqwest::multipart::Part, OpenAIError> {
+    let file_name = path
+        .as_ref()
+        .file_name()
+        .ok_or_else(|| {
+            OpenAIError::FileReadError(format!(
+                "cannot extract file name from {}",
+                path.as_ref().display()
+            ))
+        })?
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let file_part = reqwest::multipart::Part::stream(file_stream_body(path.as_ref()).await?)
+        .file_name(file_name)
+        .mime_str("application/octet-stream")
+        .unwrap();
+
+    Ok(file_part)
+}


### PR DESCRIPTION
- types supporting list, delete, retrieve, retrieve contents for an OpenAIFile
- unit test to test all the functions (except retrieve contents as it is not allowed for free accounts)
- use generic error names `FileSaveError`, `FileReadError` for file related errors in `file.rs` module or `image.rs` module