### PR TITLE
Handle rate limiting

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/64bit/async-openai"
 
 
 [dependencies]
+backoff = {version = "0.4.0", features = ["tokio"] }
 base64 = "0.13.1"
 futures = "0.3.25"
 rand = "0.8.5"

--- a/async-openai/README.md
+++ b/async-openai/README.md
@@ -19,6 +19,7 @@
 `async-openai` is an unofficial Rust library for OpenAI REST API.
 
 - It's based on [OpenAI OpenAPI spec](https://github.com/openai/openai-openapi)
+- Non-streaming requests are retried with exponential backoff when [rate limited](https://help.openai.com/en/articles/5955598-is-api-usage-subject-to-any-rate-limits) by the API server.
 - Current features:
   - [x] Completions (including SSE streaming)
   - [x] Edits

--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -136,7 +136,7 @@ impl Client {
         Ok(response)
     }
 
-    /// Execute any HTTP requests except the streaming ones as they cannot be cloned for retrying.
+    /// Execute any HTTP requests and retry on rate limit, except streaming ones as they cannot be cloned for retrying.
     async fn execute<O>(&self, request: reqwest::Request) -> Result<O, OpenAIError>
     where
         O: DeserializeOwned,

--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -9,6 +9,7 @@ pub struct Client {
     api_key: String,
     api_base: String,
     org_id: String,
+    backoff: backoff::ExponentialBackoff,
     //headers: reqwest::header::HeaderMap,
 }
 
@@ -42,12 +43,77 @@ impl Client {
         self
     }
 
+    /// Exponential backoff for retrying [rate limited](https://help.openai.com/en/articles/5955598-is-api-usage-subject-to-any-rate-limits) requests. Form submissions are not retried.
+    pub fn with_backoff(mut self, backoff: backoff::ExponentialBackoff) -> Self {
+        self.backoff = backoff;
+        self
+    }
+
     pub fn api_base(&self) -> &str {
         &self.api_base
     }
 
     pub fn api_key(&self) -> &str {
         &self.api_key
+    }
+
+    /// Make a GET request to {path} and deserialize the response body
+    pub(crate) async fn get<O>(&self, path: &str) -> Result<O, OpenAIError>
+    where
+        O: DeserializeOwned,
+    {
+        let request = reqwest::Client::new()
+            .get(format!("{}{path}", self.api_base()))
+            .bearer_auth(self.api_key())
+            .build()?;
+
+        self.execute(request).await
+    }
+
+    /// Make a DELETE request to {path} and deserialize the response body
+    pub(crate) async fn delete<O>(&self, path: &str) -> Result<O, OpenAIError>
+    where
+        O: DeserializeOwned,
+    {
+        let request = reqwest::Client::new()
+            .delete(format!("{}{path}", self.api_base()))
+            .bearer_auth(self.api_key())
+            .build()?;
+
+        self.execute(request).await
+    }
+
+    /// Make a POST request to {path} and deserialize the response body
+    pub(crate) async fn post<I, O>(&self, path: &str, request: I) -> Result<O, OpenAIError>
+    where
+        I: Serialize,
+        O: DeserializeOwned,
+    {
+        let request = reqwest::Client::new()
+            .post(format!("{}{path}", self.api_base()))
+            .bearer_auth(self.api_key())
+            .json(&request)
+            .build()?;
+
+        self.execute(request).await
+    }
+
+    /// POST a form at {path} and deserialize the response body
+    pub(crate) async fn post_form<O>(
+        &self,
+        path: &str,
+        form: reqwest::multipart::Form,
+    ) -> Result<O, OpenAIError>
+    where
+        O: DeserializeOwned,
+    {
+        let request = reqwest::Client::new()
+            .post(format!("{}{path}", self.api_base()))
+            .bearer_auth(self.api_key())
+            .multipart(form)
+            .build()?;
+
+        self.execute(request).await
     }
 
     /// Deserialize response body from either error object or actual response object
@@ -70,66 +136,60 @@ impl Client {
         Ok(response)
     }
 
-    /// Make a GET request to {path} and deserialize the response body
-    pub(crate) async fn get<O>(&self, path: &str) -> Result<O, OpenAIError>
+    /// Execute any HTTP requests except the streaming ones as they cannot be cloned for retrying.
+    async fn execute<O>(&self, request: reqwest::Request) -> Result<O, OpenAIError>
     where
         O: DeserializeOwned,
     {
-        let response = reqwest::Client::new()
-            .get(format!("{}{path}", self.api_base()))
-            .bearer_auth(self.api_key())
-            .send()
-            .await?;
+        let client = reqwest::Client::new();
 
-        self.process_response(response).await
-    }
+        match request.try_clone() {
+            // Only clone-able requests can be retried
+            Some(request) => {
+                backoff::future::retry(self.backoff.clone(), || async {
+                    let response = client
+                        .execute(request.try_clone().unwrap())
+                        .await
+                        .map_err(OpenAIError::Reqwest)
+                        .map_err(backoff::Error::Permanent)?;
 
-    /// Make a DELETE request to {path} and deserialize the response body
-    pub(crate) async fn delete<O>(&self, path: &str) -> Result<O, OpenAIError>
-    where
-        O: DeserializeOwned,
-    {
-        let response = reqwest::Client::new()
-            .delete(format!("{}{path}", self.api_base()))
-            .bearer_auth(self.api_key())
-            .send()
-            .await?;
+                    let status = response.status();
+                    let bytes = response
+                        .bytes()
+                        .await
+                        .map_err(OpenAIError::Reqwest)
+                        .map_err(backoff::Error::Permanent)?;
 
-        self.process_response(response).await
-    }
+                    // Deserialize response body from either error object or actual response object
+                    if !status.is_success() {
+                        let wrapped_error: WrappedError = serde_json::from_slice(bytes.as_ref())
+                            .map_err(OpenAIError::JSONDeserialize)
+                            .map_err(backoff::Error::Permanent)?;
 
-    /// Make a POST request to {path} and deserialize the response body
-    pub(crate) async fn post<I, O>(&self, path: &str, request: I) -> Result<O, OpenAIError>
-    where
-        I: Serialize,
-        O: DeserializeOwned,
-    {
-        let response = reqwest::Client::new()
-            .post(format!("{}{path}", self.api_base()))
-            .bearer_auth(self.api_key())
-            .json(&request)
-            .send()
-            .await?;
+                        if status.as_u16() == 429 {
+                            // Rate limited retry...
+                            return Err(backoff::Error::Transient {
+                                err: OpenAIError::ApiError(wrapped_error.error),
+                                retry_after: None,
+                            });
+                        } else {
+                            return Err(backoff::Error::Permanent(OpenAIError::ApiError(
+                                wrapped_error.error,
+                            )));
+                        }
+                    }
 
-        self.process_response(response).await
-    }
-
-    /// POST a form at {path} and deserialize the response body
-    pub(crate) async fn post_form<O>(
-        &self,
-        path: &str,
-        form: reqwest::multipart::Form,
-    ) -> Result<O, OpenAIError>
-    where
-        O: DeserializeOwned,
-    {
-        let response = reqwest::Client::new()
-            .post(format!("{}{path}", self.api_base()))
-            .bearer_auth(self.api_key())
-            .multipart(form)
-            .send()
-            .await?;
-
-        self.process_response(response).await
+                    let response: O = serde_json::from_slice(bytes.as_ref())
+                        .map_err(OpenAIError::JSONDeserialize)
+                        .map_err(backoff::Error::Permanent)?;
+                    Ok(response)
+                })
+                .await
+            }
+            None => {
+                let response = client.execute(request).await?;
+                self.process_response(response).await
+            }
+        }
     }
 }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "create-image-edit",
     "create-image-variation",
     "models",
-    "moderations"
+    "moderations",
+    "rate-limit-completions",
 ]
 resolver = "2"

--- a/examples/rate-limit-completions/Cargo.toml
+++ b/examples/rate-limit-completions/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rate-limit-completions"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+async-openai = {path = "../../async-openai"}
+backoff = { version = "0.4.0", features = ["tokio"] }
+tokio = {version = "1.22.0", features = ["full"]}

--- a/examples/rate-limit-completions/src/main.rs
+++ b/examples/rate-limit-completions/src/main.rs
@@ -1,0 +1,38 @@
+use async_openai as openai;
+use openai::{error::OpenAIError, types::CreateCompletionRequest, Client, Completion};
+
+async fn joke(client: &Client) -> Result<String, OpenAIError> {
+    let request = CreateCompletionRequest {
+        model: "text-davinci-003".to_owned(),
+        prompt: Some("Tell me a joke".to_owned()),
+        max_tokens: Some(30),
+        ..Default::default()
+    };
+
+    let response = Completion::create(&client, request).await?;
+
+    Ok(response.choices.first().unwrap().text.to_string())
+}
+
+#[tokio::main]
+async fn main() {
+    let backoff = backoff::ExponentialBackoffBuilder::new()
+        .with_max_elapsed_time(Some(std::time::Duration::from_secs(60)))
+        .build();
+
+    let client = Client::new().with_backoff(backoff);
+    let mut count = 100;
+
+    // Make back to back requests in a loop to trigger rate limits
+    // which will be retried by exponential backoff
+    while count > 0 {
+        match joke(&client).await {
+            Ok(joke) => println!("{joke}"),
+            Err(e) => {
+                eprintln!("{e}");
+                break;
+            }
+        }
+        count -= 1;
+    }
+}


### PR DESCRIPTION
- Retry with exponential backoff on rate limits
- Only non stream requests are retried. Form submissions are not retried. 
- Add example to send back to back requests to trigger rate limit and retries.