### PR TITLE
Support for Organization id header; Support to log rate limit warning

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "1.0.37"
 tokio = { version = "1.22.0", features = ["fs", "macros"] }
 tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["codec", "io-util"] }
+tracing = "0.1.37"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -15,6 +15,7 @@ pub struct Client {
 
 /// Default v1 API base url
 pub const API_BASE: &str = "https://api.openai.com/v1";
+/// Name for organization header
 pub const ORGANIZATION_HEADER: &str = "OpenAI-Organization";
 
 impl Client {

--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -1,20 +1,21 @@
+use reqwest::header::HeaderMap;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::error::{OpenAIError, WrappedError};
 
 #[derive(Debug, Default)]
-/// Client container for api key, base url and other metadata
-/// required to make API calls.
+/// Client is a container for api key, base url, organization id, and backoff
+/// configuration used to make API calls.
 pub struct Client {
     api_key: String,
     api_base: String,
     org_id: String,
     backoff: backoff::ExponentialBackoff,
-    //headers: reqwest::header::HeaderMap,
 }
 
 /// Default v1 API base url
 pub const API_BASE: &str = "https://api.openai.com/v1";
+pub const ORGANIZATION_HEADER: &str = "OpenAI-Organization";
 
 impl Client {
     /// Create client with default [API_BASE] url and default API key from OPENAI_API_KEY env var
@@ -32,6 +33,7 @@ impl Client {
         self
     }
 
+    /// To use a different organization id other than default
     pub fn with_org_id<S: Into<String>>(mut self, org_id: S) -> Self {
         self.org_id = org_id.into();
         self
@@ -57,6 +59,14 @@ impl Client {
         &self.api_key
     }
 
+    fn headers(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        if !self.org_id.is_empty() {
+            headers.insert(ORGANIZATION_HEADER, self.org_id.as_str().parse().unwrap());
+        }
+        headers
+    }
+
     /// Make a GET request to {path} and deserialize the response body
     pub(crate) async fn get<O>(&self, path: &str) -> Result<O, OpenAIError>
     where
@@ -65,6 +75,7 @@ impl Client {
         let request = reqwest::Client::new()
             .get(format!("{}{path}", self.api_base()))
             .bearer_auth(self.api_key())
+            .headers(self.headers())
             .build()?;
 
         self.execute(request).await
@@ -78,6 +89,7 @@ impl Client {
         let request = reqwest::Client::new()
             .delete(format!("{}{path}", self.api_base()))
             .bearer_auth(self.api_key())
+            .headers(self.headers())
             .build()?;
 
         self.execute(request).await
@@ -92,6 +104,7 @@ impl Client {
         let request = reqwest::Client::new()
             .post(format!("{}{path}", self.api_base()))
             .bearer_auth(self.api_key())
+            .headers(self.headers())
             .json(&request)
             .build()?;
 
@@ -110,6 +123,7 @@ impl Client {
         let request = reqwest::Client::new()
             .post(format!("{}{path}", self.api_base()))
             .bearer_auth(self.api_key())
+            .headers(self.headers())
             .multipart(form)
             .build()?;
 
@@ -166,8 +180,13 @@ impl Client {
                             .map_err(OpenAIError::JSONDeserialize)
                             .map_err(backoff::Error::Permanent)?;
 
-                        if status.as_u16() == 429 {
+                        if status.as_u16() == 429
+                            // API returns 429 also when:
+                            // "You exceeded your current quota, please check your plan and billing details."
+                            && wrapped_error.error.r#type != "insufficient_quota"
+                        {
                             // Rate limited retry...
+                            tracing::warn!("Rate limited: {}", wrapped_error.error.message);
                             return Err(backoff::Error::Transient {
                                 err: OpenAIError::ApiError(wrapped_error.error),
                                 retry_after: None,

--- a/async-openai/src/error.rs
+++ b/async-openai/src/error.rs
@@ -36,7 +36,7 @@ pub struct ApiError {
 }
 
 /// Wrapper to deserialize the error object nested in "error" JSON key
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub(crate) struct WrappedError {
     pub(crate) error: ApiError,
 }

--- a/async-openai/src/lib.rs
+++ b/async-openai/src/lib.rs
@@ -9,8 +9,11 @@
 //! let client = openai::Client::new();
 //!
 //! // OR use API key from different source
-//! let api_key = "sk-..."; // This could be from a file, hard coding secret is not a best practice.
+//! let api_key = "sk-..."; // This secret could be from a file, or environment variable.
 //! let client = openai::Client::new().with_api_key(api_key);
+//!
+//! // Use organization different then default when making requests
+//! let client = openai::Client::new().with_org_id("the-org");
 //! ```
 //!
 //! ## Making requests

--- a/async-openai/src/lib.rs
+++ b/async-openai/src/lib.rs
@@ -57,6 +57,7 @@ mod util;
 
 pub use client::Client;
 pub use client::API_BASE;
+pub use client::ORGANIZATION_HEADER;
 pub use completion::Completion;
 pub use edit::Edit;
 pub use embedding::Embeddings;

--- a/examples/rate-limit-completions/Cargo.toml
+++ b/examples/rate-limit-completions/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 async-openai = {path = "../../async-openai"}
 backoff = { version = "0.4.0", features = ["tokio"] }
 tokio = {version = "1.22.0", features = ["full"]}
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"]}

--- a/examples/rate-limit-completions/src/main.rs
+++ b/examples/rate-limit-completions/src/main.rs
@@ -1,9 +1,11 @@
 use async_openai as openai;
 use openai::{error::OpenAIError, types::CreateCompletionRequest, Client, Completion};
 
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
 async fn joke(client: &Client) -> Result<String, OpenAIError> {
     let request = CreateCompletionRequest {
-        model: "text-davinci-003".to_owned(),
+        model: "text-ada-001".to_owned(),
         prompt: Some("Tell me a joke".to_owned()),
         max_tokens: Some(30),
         ..Default::default()
@@ -16,6 +18,15 @@ async fn joke(client: &Client) -> Result<String, OpenAIError> {
 
 #[tokio::main]
 async fn main() {
+    // This should come from env var outside the program
+    std::env::set_var("RUST_LOG", "warn");
+
+    // Setup tracing subscriber so that library can log the rate limited message
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
     let backoff = backoff::ExponentialBackoffBuilder::new()
         .with_max_elapsed_time(Some(std::time::Duration::from_secs(60)))
         .build();


### PR DESCRIPTION
- Support `OpenAI-Organization: my-org` header 
- Add tracing to log warning when a request is rate limited
- Update `rate-limit-completions` example to actually log the rate limit warning (previous this would be siliently retried without any feedback to library user - logging makes it visibile to the library user)