### PR TITLE
Adding Send bound to boxed future types

### DIFF
--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -279,7 +279,7 @@ impl Client {
         &self,
         path: &str,
         request: I,
-    ) -> Pin<Box<dyn Stream<Item = Result<O, OpenAIError>>>>
+    ) -> Pin<Box<dyn Stream<Item = Result<O, OpenAIError>> + Send>>
     where
         I: Serialize,
         O: DeserializeOwned + std::marker::Send + 'static,
@@ -300,7 +300,7 @@ impl Client {
         &self,
         path: &str,
         query: &Q,
-    ) -> Pin<Box<dyn Stream<Item = Result<O, OpenAIError>>>>
+    ) -> Pin<Box<dyn Stream<Item = Result<O, OpenAIError>> + Send>>
     where
         Q: Serialize + ?Sized,
         O: DeserializeOwned + std::marker::Send + 'static,
@@ -320,7 +320,7 @@ impl Client {
     /// [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format)
     pub(crate) async fn stream<O>(
         mut event_source: EventSource,
-    ) -> Pin<Box<dyn Stream<Item = Result<O, OpenAIError>>>>
+    ) -> Pin<Box<dyn Stream<Item = Result<O, OpenAIError>> + Send>>
     where
         O: DeserializeOwned + std::marker::Send + 'static,
     {

--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -169,7 +169,7 @@ pub struct CreateCompletionResponse {
 
 /// Parsed server side events stream until an \[DONE\] is received from server.
 pub type CompletionResponseStream =
-    Pin<Box<dyn Stream<Item = Result<CreateCompletionResponse, OpenAIError>>>>;
+    Pin<Box<dyn Stream<Item = Result<CreateCompletionResponse, OpenAIError>> + Send>>;
 
 #[derive(Debug, Clone, Serialize, Default, Builder)]
 #[builder(name = "CreateEditRequestArgs")]
@@ -616,7 +616,7 @@ pub struct ListFineTuneEventsResponse {
 
 /// Parsed server side events stream until an \[DONE\] is received from server.
 pub type FineTuneEventsResponseStream =
-    Pin<Box<dyn Stream<Item = Result<ListFineTuneEventsResponse, OpenAIError>>>>;
+    Pin<Box<dyn Stream<Item = Result<ListFineTuneEventsResponse, OpenAIError>> + Send>>;
 
 #[derive(Debug, Deserialize)]
 pub struct DeleteModelResponse {

--- a/async-openai/tests/boxed_future.rs
+++ b/async-openai/tests/boxed_future.rs
@@ -1,0 +1,44 @@
+
+use futures::StreamExt;
+use futures::future::{BoxFuture, FutureExt};
+
+use async_openai::Client;
+use async_openai::types::{CompletionResponseStream, CreateCompletionRequestArgs};
+
+#[tokio::test]
+async fn boxed_future_test() {
+
+    fn interpret_bool(token_stream: &mut CompletionResponseStream) -> BoxFuture<'_, bool> {
+        async move {
+            while let Some(response) = token_stream.next().await {
+                match response {
+                    Ok(response) => {
+                        let token_str = &response.choices[0].text.trim();
+                        if !token_str.is_empty() {
+                            return token_str.contains("yes") || token_str.contains("Yes");
+                        }
+                    },
+                    Err(_) => panic!()
+                }
+            }
+            false
+        }.boxed()
+    }
+
+    let client = Client::new();
+
+    let request = CreateCompletionRequestArgs::default()
+        .model("text-babbage-001")
+        .n(1)
+        .prompt("does 2 and 2 add to four? (yes/no):\n")
+        .stream(true)
+        .logprobs(3)
+        .max_tokens(64_u16)
+        .build().unwrap();
+
+    let mut stream = client.completions().create_stream(request).await.unwrap();
+
+    let result = interpret_bool(&mut stream).await;
+    assert_eq!(result, true);
+
+}

--- a/async-openai/tests/boxed_future.rs
+++ b/async-openai/tests/boxed_future.rs
@@ -18,7 +18,7 @@ async fn boxed_future_test() {
                             return token_str.contains("yes") || token_str.contains("Yes");
                         }
                     },
-                    Err(_) => panic!()
+                    Err(e) => eprintln!("Error: {e}"),
                 }
             }
             false


### PR DESCRIPTION
This is needed so the types can be sent between threads in a multithreaded runtime.

https://github.com/64bit/async-openai/issues/36

Thank you.