### PR TITLE
ChatChoice finish_reason can be null

### DIFF
--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -771,7 +771,7 @@ pub struct CreateChatCompletionRequest {
 pub struct ChatChoice {
     pub index: u32,
     pub message: ChatCompletionResponseMessage,
-    pub finish_reason: String,
+    pub finish_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
finish_reason can sometimes be null in CreateChatCompletionResponse.