### PR TITLE
Fix: invalid_request_error: None is not of type 'string' - 'user'

### DIFF
--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -771,6 +771,7 @@ pub struct CreateChatCompletionRequest {
     pub logit_bias: Option<HashMap<String, serde_json::Value>>, // default: null
 
     /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
 }
 


### PR DESCRIPTION
This Pr should fix `Error: invalid_request_error: None is not of type 'string' - 'user'` error from the API.

On latest version of the library my requests are failing with the mentioned error. I assume this is because serde json will be default populate the field with `"null"` and the API expects it to be missing if it's not set?

`skip_serializing_if ` is already implemented on a lot of other fields and I suspect that it might also need to be added to others