### PR TITLE
Add reqwest/native-tls-vendored feature

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -20,6 +20,8 @@ default = ["rustls"]
 rustls = ["reqwest/rustls-tls-native-roots"]
 # Enable native-tls for TLS support
 native-tls = ["reqwest/native-tls"]
+# Remove dependency on OpenSSL
+native-tls-vendored = ["reqwest/native-tls-vendored"]
 
 [dependencies]
 backoff = {version = "0.4.0", features = ["tokio"] }


### PR DESCRIPTION
Hey, first of all thanks for the awesome crate.

I run my rust services on ARM-based AWS graviton instances which have a different version of OpenSSL that doesn't play nicely with reqwest. This diff adds a new feature to async-openai that allows removing the dependency on OpenSSL by opting in for the native-tls-vendored feature in the reqwest library. 

I've tested this on graviton with an incompatible version of OpenSSL and things work nicely :)

Thanks