### PR TITLE
Fix streaming function calls

### DIFF
--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -862,11 +862,18 @@ pub struct CreateChatCompletionResponse {
 pub type ChatCompletionResponseStream =
     Pin<Box<dyn Stream<Item = Result<CreateChatCompletionStreamResponse, OpenAIError>> + Send>>;
 
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct FunctionCallStream {
+    pub name: Option<String>,
+    pub arguments: Option<String>,
+}
+
 // For reason (not documented by OpenAI) the response from stream is different
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct ChatCompletionResponseStreamMessage {
     pub content: Option<String>,
+    pub function_call: Option<FunctionCallStream>,
     pub role: Option<Role>,
 }
 


### PR DESCRIPTION
Hello!

This fixes a bug that broke streaming chat responses with function calls. From observation, `arguments` is always a string, however, just to be safe, I've made it an `Option<String>`.