### PR TITLE
Fix api base in url

### DIFF
--- a/async-openai/src/config.rs
+++ b/async-openai/src/config.rs
@@ -84,7 +84,7 @@ impl Config for OpenAIConfig {
     }
 
     fn url(&self, path: &str) -> String {
-        format!("{}{}", OPENAI_API_BASE, path)
+        format!("{}{}", self.api_base, path)
     }
 
     fn api_base(&self) -> &str {


### PR DESCRIPTION
Hello! Thanks for this crate, which I'm using in my projects.
I found the bug: even if you specify api base in the config, the client will replace it when making a request (for openai config). So, this is the fix :)