### PR TITLE
Link to openai-func-enums

### DIFF
--- a/async-openai/README.md
+++ b/async-openai/README.md
@@ -105,6 +105,9 @@ Thank you for your time to contribute and improve the project, I'd be happy to h
 
 A good starting point would be existing [open issues](https://github.com/64bit/async-openai/issues).
 
+## Complimentary Crates:
+- [openai-func-enums](https://github.com/frankfralick/openai-func-enums) provides procedural macros that make it easier to use this library with OpenAI API's function calling feature. It also provides derive macros you can add to existing [clap](https://github.com/clap-rs/clap) application subcommands for natural language use of command line tools.
+
 ## License
 
 This project is licensed under [MIT license](https://github.com/64bit/async-openai/blob/main/LICENSE).


### PR DESCRIPTION
This pull request is in response to issue #87.  Also, since I opened this, @WestXu asked about integration with [clap](https://github.com/clap-rs/clap), which I've done now and it's pretty fun. You can see an example of integrating async-openai with clap [here](https://github.com/frankfralick/openai-func-enums#integration-with-clap). Thanks again.