### PR TITLE
Made ApiError `r#type` optional to support Azure Error responses

### DIFF
--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -231,7 +231,7 @@ impl<C: Config> Client<C> {
                         if status.as_u16() == 429
                             // API returns 429 also when:
                             // "You exceeded your current quota, please check your plan and billing details."
-                            && wrapped_error.error.r#type != "insufficient_quota"
+                            && wrapped_error.error.r#type != Some("insufficient_quota".to_string())
                         {
                             // Rate limited retry...
                             tracing::warn!("Rate limited: {}", wrapped_error.error.message);

--- a/async-openai/src/error.rs
+++ b/async-openai/src/error.rs
@@ -7,7 +7,7 @@ pub enum OpenAIError {
     #[error("http error: {0}")]
     Reqwest(#[from] reqwest::Error),
     /// OpenAI returns error object with details of API call failure
-    #[error("{}: {}", .0.r#type, .0.message)]
+    #[error("{:?}: {}", .0.r#type, .0.message)]
     ApiError(ApiError),
     /// Error when a response cannot be deserialized into a Rust type
     #[error("failed to deserialize api response: {0}")]
@@ -31,7 +31,7 @@ pub enum OpenAIError {
 #[derive(Debug, Deserialize)]
 pub struct ApiError {
     pub message: String,
-    pub r#type: String,
+    pub r#type: Option<String>,
     pub param: Option<serde_json::Value>,
     pub code: Option<serde_json::Value>,
 }


### PR DESCRIPTION
Made `ApiError::r#type` an optional string to support the mismatch between Azure and OpenAI's specification. This will at least let Azure users view the actual error instead of receiving JSON Deserialization errors.

Discussed in #94 