### PR TITLE
add  deserialization for OpenAIConfig and AzureConfig

### DIFF
--- a/async-openai/src/config.rs
+++ b/async-openai/src/config.rs
@@ -1,5 +1,6 @@
 //! Client configurations: [OpenAIConfig] for OpenAI, [AzureConfig] for Azure OpenAI Service.
 use reqwest::header::{HeaderMap, AUTHORIZATION};
+use serde::Deserialize;
 
 /// Default v1 API base url
 pub const OPENAI_API_BASE: &str = "https://api.openai.com/v1";
@@ -19,7 +20,8 @@ pub trait Config: Clone {
 }
 
 /// Configuration for OpenAI API
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
 pub struct OpenAIConfig {
     api_base: String,
     api_key: String,
@@ -101,7 +103,8 @@ impl Config for OpenAIConfig {
 }
 
 /// Configuration for Azure OpenAI Service
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
 pub struct AzureConfig {
     api_version: String,
     deployment_id: String,


### PR DESCRIPTION
This should close #107. Arguably, the deserialization uses `Default` when a field is not given during deserialization and thus is too permissive. As far as I know,  Azure APIs needs all fields in `AzureConfig` to be valid ones, but the defaults are not.