### PR TITLE
Better ChatCompletionFunctionCall interface

### DIFF
--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -356,7 +356,7 @@ impl From<&str> for ChatCompletionFunctionCall {
         match value {
             "none" => Self::None,
             "auto" => Self::Auto,
-            _ => Self::Function(value.to_string()),
+            _ => Self::Function { name: value.to_string() },
         }
     }
 }

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -3,8 +3,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use serde::{ser::SerializeMap, Serialize};
-
 use crate::{
     download::{download_url, save_b64},
     error::OpenAIError,

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -3,6 +3,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use serde::{ser::SerializeMap, Serialize};
+
 use crate::{
     download::{download_url, save_b64},
     error::OpenAIError,

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -361,28 +361,6 @@ impl From<&str> for ChatCompletionFunctionCall {
     }
 }
 
-impl Serialize for ChatCompletionFunctionCall {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            ChatCompletionFunctionCall::None => serializer.serialize_str("none"),
-            ChatCompletionFunctionCall::Auto => serializer.serialize_str("auto"),
-            ChatCompletionFunctionCall::Function(s) => {
-                let mut map = serializer.serialize_map(Some(1))?;
-                map.serialize_entry("name", s)?;
-                map.end()
-            }
-        }
-    }
-}
-
-impl<'de> serde::de::Deserialize<'de> for ChatCompletionFunctionCall {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-
-        Ok(s.as_str().into())
     }
 }
 

--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -44,7 +44,7 @@ pub enum ChatCompletionFunctionCall {
     /// The model can pick between an end-user or calling a function.
     Auto,
     /// Forces the model to call the specified function.
-    Function(String),
+    Function { name : String },
 }
 
 #[derive(Clone, Serialize, Default, Debug, Builder, PartialEq)]

--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -784,7 +784,10 @@ pub struct CreateChatCompletionRequest {
     pub functions: Option<Vec<ChatCompletionFunctions>>,
 
     /// Controls how the model responds to function calls.
-    /// None is the default when no functions are present. Auto is the default if functions are present.
+    /// "none" means the model does not call a function, and responds to the end-user.
+    /// "auto" means the model can pick between an end-user or calling a function.
+    /// Specifying a particular function via `{"name":\ "my_function"}` forces the model to call that function.
+    /// "none" is the default when no functions are present. "auto" is the default if functions are present.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function_call: Option<ChatCompletionFunctionCall>,
 

--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, path::PathBuf, pin::Pin};
 
 use derive_builder::Builder;
 use futures::Stream;
-use serde::{ser::SerializeMap, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::error::OpenAIError;
 

--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -39,38 +39,12 @@ pub enum Stop {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ChatCompletionFunctionCall {
+    /// The model does not call a function, and responds to the end-user.
     None,
+    /// The model can pick between an end-user or calling a function.
     Auto,
+    /// Forces the model to call the specified function.
     Function(String),
-}
-
-impl Serialize for ChatCompletionFunctionCall {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            ChatCompletionFunctionCall::None => serializer.serialize_str("none"),
-            ChatCompletionFunctionCall::Auto => serializer.serialize_str("auto"),
-            ChatCompletionFunctionCall::Function(s) => {
-                let mut map = serializer.serialize_map(Some(1))?;
-                map.serialize_entry("name", s)?;
-                map.end()
-            }
-        }
-    }
-}
-
-impl<'de> serde::de::Deserialize<'de> for ChatCompletionFunctionCall {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-
-        match s.as_str() {
-            "none" => Ok(ChatCompletionFunctionCall::None),
-            "auto" => Ok(ChatCompletionFunctionCall::Auto),
-            _ => Ok(ChatCompletionFunctionCall::Function(s)),
-        }
-    }
 }
 
 #[derive(Clone, Serialize, Default, Debug, Builder, PartialEq)]
@@ -810,10 +784,7 @@ pub struct CreateChatCompletionRequest {
     pub functions: Option<Vec<ChatCompletionFunctions>>,
 
     /// Controls how the model responds to function calls.
-    /// "none" means the model does not call a function, and responds to the end-user.
-    /// "auto" means the model can pick between an end-user or calling a function.
-    /// Specifying a particular function via `{"name":\ "my_function"}` forces the model to call that function.
-    /// "none" is the default when no functions are present. "auto" is the default if functions are present.
+    /// None is the default when no functions are present. Auto is the default if functions are present.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function_call: Option<ChatCompletionFunctionCall>,
 


### PR DESCRIPTION
According to [OpenAI's docs](https://platform.openai.com/docs/api-reference/chat/create), the `function_call` parameter can only be either `none`, `auto`, or `{ "name": function_name }`.

The current interface in this library feels counter-intuitive, and I've often tried to call a custom function using `ChatCompletionFunctionCall::String(function_name)` instead of `ChatCompletionFunctionCall::Object(json!({ "name": custom_function }))`.

This change proposes a more intuitive interface for this (as a breaking change unfortunately).