### PR TITLE
add feature gate for tokio

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -15,7 +15,9 @@ homepage = "https://github.com/64bit/async-openai"
 repository = "https://github.com/64bit/async-openai"
 
 [features]
-default = ["rustls"]
+default = ["rustls", "enable_tokio"]
+# Enable tokio
+enable_tokio = ["backoff/tokio", "tokio", "tokio-util", "tokio-stream"]
 # Enable rustls for TLS support
 rustls = ["reqwest/rustls-tls-native-roots"]
 # Enable native-tls for TLS support
@@ -24,7 +26,7 @@ native-tls = ["reqwest/native-tls"]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
 
 [dependencies]
-backoff = {version = "0.4.0", features = ["tokio"] }
+backoff = {version = "0.4.0", features = ["futures"] }
 base64 = "0.21.0"
 futures = "0.3.26"
 rand = "0.8.5"
@@ -33,13 +35,14 @@ reqwest-eventsource = "0.4.0"
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.93"
 thiserror = "1.0.38"
-tokio = { version = "1.25.0", features = ["fs", "macros"] }
-tokio-stream = "0.1.11"
-tokio-util = { version = "0.7.7", features = ["codec", "io-util"] }
 tracing = "0.1.37"
 derive_builder = "0.12.0"
 async-convert = "1.0.0"
 secrecy = { version = "0.8.0", features=["serde"] }
+tokio = { version = "1.25.0", features = ["fs", "macros"], optional = true }
+tokio-stream = { version = "0.1.11", optional = true }
+tokio-util = { version = "0.7.7", features = ["codec", "io-util"], optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4.2"
+tokio = { version = "1.25.0", features = ["fs", "macros"] }

--- a/async-openai/src/chat.rs
+++ b/async-openai/src/chat.rs
@@ -2,10 +2,13 @@ use crate::{
     config::Config,
     error::OpenAIError,
     types::{
-        ChatCompletionResponseStream, CreateChatCompletionRequest, CreateChatCompletionResponse,
+        CreateChatCompletionRequest, CreateChatCompletionResponse,
     },
     Client,
 };
+
+#[cfg(feature = "enable_tokio")]
+use crate::types::ChatCompletionResponseStream;
 
 /// Given a chat conversation, the model will return a chat completion response.
 pub struct Chat<'c, C: Config> {
@@ -30,6 +33,7 @@ impl<'c, C: Config> Chat<'c, C> {
         self.client.post("/chat/completions", request).await
     }
 
+    #[cfg(feature = "tokio")]
     /// Creates a completion for the chat message
     ///
     /// partial message deltas will be sent, like in ChatGPT. Tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format) as they become available, with the stream terminated by a `data: [DONE]` message.

--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -6,12 +6,18 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
     config::{Config, OpenAIConfig},
-    edit::Edits,
     error::{map_deserialization_error, OpenAIError, WrappedError},
+    moderation::Moderations,
+    Chat, Completions, Embeddings, Models,
+};
+
+#[cfg(feature = "enable_tokio")]
+use crate::{
+    edit::Edits,
     file::Files,
     image::Images,
-    moderation::Moderations,
-    Audio, Chat, Completions, Embeddings, FineTunes, Models,
+    Audio,
+    FineTunes
 };
 
 #[derive(Debug, Clone)]
@@ -75,11 +81,13 @@ impl<C: Config> Client<C> {
         Chat::new(self)
     }
 
+    #[cfg(feature = "enable_tokio")]
     /// To call [Edits] group related APIs using this client.
     pub fn edits(&self) -> Edits<C> {
         Edits::new(self)
     }
 
+    #[cfg(feature = "enable_tokio")]
     /// To call [Images] group related APIs using this client.
     pub fn images(&self) -> Images<C> {
         Images::new(self)
@@ -90,11 +98,13 @@ impl<C: Config> Client<C> {
         Moderations::new(self)
     }
 
+    #[cfg(feature = "enable_tokio")]
     /// To call [Files] group related APIs using this client.
     pub fn files(&self) -> Files<C> {
         Files::new(self)
     }
 
+    #[cfg(feature = "enable_tokio")]
     /// To call [FineTunes] group related APIs using this client.
     pub fn fine_tunes(&self) -> FineTunes<C> {
         FineTunes::new(self)
@@ -105,6 +115,7 @@ impl<C: Config> Client<C> {
         Embeddings::new(self)
     }
 
+    #[cfg(feature = "enable_tokio")]
     /// To call [Audio] group related APIs using this client.
     pub fn audio(&self) -> Audio<C> {
         Audio::new(self)
@@ -243,6 +254,7 @@ impl<C: Config> Client<C> {
         .await
     }
 
+    #[cfg(feature = "enable_tokio")]
     /// Make HTTP POST request to receive SSE
     pub(crate) async fn post_stream<I, O>(
         &self,
@@ -265,6 +277,7 @@ impl<C: Config> Client<C> {
         stream(event_source).await
     }
 
+    #[cfg(feature = "enable_tokio")]
     /// Make HTTP GET request to receive SSE
     pub(crate) async fn get_stream<Q, O>(
         &self,
@@ -288,6 +301,7 @@ impl<C: Config> Client<C> {
     }
 }
 
+#[cfg(feature = "enable_tokio")]
 /// Request which responds with SSE.
 /// [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format)
 pub(crate) async fn stream<O>(

--- a/async-openai/src/completion.rs
+++ b/async-openai/src/completion.rs
@@ -2,8 +2,11 @@ use crate::{
     client::Client,
     config::Config,
     error::OpenAIError,
-    types::{CompletionResponseStream, CreateCompletionRequest, CreateCompletionResponse},
+    types::{CreateCompletionRequest, CreateCompletionResponse},
 };
+
+#[cfg(feature = "enable_tokio")]
+use crate::types::CompletionResponseStream;
 
 /// Given a prompt, the model will return one or more predicted
 /// completions, and can also return the probabilities of alternative
@@ -30,6 +33,7 @@ impl<'c, C: Config> Completions<'c, C> {
         self.client.post("/completions", request).await
     }
 
+    #[cfg(feature = "enable_tokio")]
     /// Creates a completion request for the provided prompt and parameters
     ///
     /// Stream back partial progress. Tokens will be sent as data-only

--- a/async-openai/src/lib.rs
+++ b/async-openai/src/lib.rs
@@ -76,31 +76,44 @@
 //! ## Examples
 //! For full working examples for all supported features see [examples](https://github.com/64bit/async-openai/tree/main/examples) directory in the repository.
 //!
+
+#[cfg(feature = "enable_tokio")]
 mod audio;
 mod chat;
 mod client;
 mod completion;
 pub mod config;
+#[cfg(feature = "enable_tokio")]
 mod download;
+#[cfg(feature = "enable_tokio")]
 mod edit;
 mod embedding;
 pub mod error;
+#[cfg(feature = "enable_tokio")]
 mod file;
+#[cfg(feature = "enable_tokio")]
 mod fine_tune;
+#[cfg(feature = "enable_tokio")]
 mod image;
 mod model;
 mod moderation;
 pub mod types;
+#[cfg(feature = "enable_tokio")]
 mod util;
 
+#[cfg(feature = "enable_tokio")]
 pub use audio::Audio;
 pub use chat::Chat;
 pub use client::Client;
 pub use completion::Completions;
+#[cfg(feature = "enable_tokio")]
 pub use edit::Edits;
 pub use embedding::Embeddings;
+#[cfg(feature = "enable_tokio")]
 pub use file::Files;
+#[cfg(feature = "enable_tokio")]
 pub use fine_tune::FineTunes;
+#[cfg(feature = "enable_tokio")]
 pub use image::Images;
 pub use model::Models;
 pub use moderation::Moderations;

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -4,17 +4,23 @@ use std::{
 };
 
 use crate::{
-    download::{download_url, save_b64},
     error::OpenAIError,
     util::create_file_part,
 };
+use super::{ChatCompletionFunctionCall, EmbeddingInput, ModerationInput, Prompt, Role, Stop};
 
+#[cfg(feature = "enable_tokio")]
+use crate::download::{download_url, save_b64};
+
+#[cfg(feature = "enable_tokio")]
 use super::{
-    AudioInput, AudioResponseFormat, ChatCompletionFunctionCall, CreateFileRequest,
+    AudioInput, AudioResponseFormat, CreateFileRequest,
     CreateImageEditRequest, CreateImageVariationRequest, CreateTranscriptionRequest,
-    CreateTranslationRequest, EmbeddingInput, FileInput, ImageData, ImageInput, ImageResponse,
-    ImageSize, ModerationInput, Prompt, ResponseFormat, Role, Stop,
+    CreateTranslationRequest, ResponseFormat,
 };
+
+#[cfg(feature = "enable_tokio")]
+use super::{FileInput, ImageData, ImageInput, ImageResponse, ImageSize};
 
 macro_rules! impl_from {
     ($from_typ:ty, $to_typ:ty) => {
@@ -94,6 +100,7 @@ file_path_input!(ImageInput);
 file_path_input!(FileInput);
 file_path_input!(AudioInput);
 
+#[cfg(feature = "enable_tokio")]
 impl Display for ImageSize {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -108,6 +115,7 @@ impl Display for ImageSize {
     }
 }
 
+#[cfg(feature = "enable_tokio")]
 impl Display for ResponseFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -121,6 +129,7 @@ impl Display for ResponseFormat {
     }
 }
 
+#[cfg(feature = "enable_tokio")]
 impl Display for AudioResponseFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -137,6 +146,7 @@ impl Display for AudioResponseFormat {
     }
 }
 
+#[cfg(feature = "enable_tokio")]
 impl Display for Role {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -152,6 +162,7 @@ impl Display for Role {
     }
 }
 
+#[cfg(feature = "enable_tokio")]
 impl ImageResponse {
     /// Save each image in a dedicated Tokio task and return paths to saved files.
     /// For [ResponseFormat::Url] each file is downloaded in dedicated Tokio task.
@@ -200,6 +211,7 @@ impl ImageResponse {
     }
 }
 
+#[cfg(feature = "enable_tokio")]
 impl ImageData {
     async fn save<P: AsRef<Path>>(&self, dir: P) -> Result<PathBuf, OpenAIError> {
         match self {
@@ -363,6 +375,7 @@ impl From<serde_json::Value> for ChatCompletionFunctionCall {
 
 // start: types to multipart from
 
+#[cfg(feature = "enable_tokio")]
 #[async_convert::async_trait]
 impl async_convert::TryFrom<CreateTranscriptionRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
@@ -389,6 +402,7 @@ impl async_convert::TryFrom<CreateTranscriptionRequest> for reqwest::multipart::
     }
 }
 
+#[cfg(feature = "enable_tokio")]
 #[async_convert::async_trait]
 impl async_convert::TryFrom<CreateTranslationRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
@@ -415,6 +429,7 @@ impl async_convert::TryFrom<CreateTranslationRequest> for reqwest::multipart::Fo
     }
 }
 
+#[cfg(feature = "enable_tokio")]
 #[async_convert::async_trait]
 impl async_convert::TryFrom<CreateImageEditRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
@@ -453,6 +468,7 @@ impl async_convert::TryFrom<CreateImageEditRequest> for reqwest::multipart::Form
     }
 }
 
+#[cfg(feature = "enable_tokio")]
 #[async_convert::async_trait]
 impl async_convert::TryFrom<CreateImageVariationRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
@@ -484,6 +500,7 @@ impl async_convert::TryFrom<CreateImageVariationRequest> for reqwest::multipart:
     }
 }
 
+#[cfg(feature = "enable_tokio")]
 #[async_convert::async_trait]
 impl async_convert::TryFrom<CreateFileRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -3,14 +3,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{
-    error::OpenAIError,
-    util::create_file_part,
-};
+use crate::error::OpenAIError;
 use super::{ChatCompletionFunctionCall, EmbeddingInput, ModerationInput, Prompt, Role, Stop};
 
 #[cfg(feature = "enable_tokio")]
 use crate::download::{download_url, save_b64};
+
+#[cfg(feature = "enable_tokio")]
+use crate::util::create_file_part;
 
 #[cfg(feature = "enable_tokio")]
 use super::{
@@ -96,8 +96,11 @@ macro_rules! file_path_input {
     };
 }
 
+#[cfg(feature = "enable_tokio")]
 file_path_input!(ImageInput);
+#[cfg(feature = "enable_tokio")]
 file_path_input!(FileInput);
+#[cfg(feature = "enable_tokio")]
 file_path_input!(AudioInput);
 
 #[cfg(feature = "enable_tokio")]

--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, path::PathBuf, pin::Pin};
+use std::{collections::HashMap, pin::Pin};
+#[cfg(feature = "enable_tokio")]
+use std::path::PathBuf;
 
 use derive_builder::Builder;
 use futures::Stream;
@@ -174,10 +176,12 @@ pub struct CreateCompletionResponse {
     pub usage: Option<Usage>,
 }
 
+#[cfg(feature = "enable_tokio")]
 /// Parsed server side events stream until an \[DONE\] is received from server.
 pub type CompletionResponseStream =
     Pin<Box<dyn Stream<Item = Result<CreateCompletionResponse, OpenAIError>> + Send>>;
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Clone, Serialize, Default, Builder, PartialEq)]
 #[builder(name = "CreateEditRequestArgs")]
 #[builder(pattern = "mutable")]
@@ -212,6 +216,7 @@ pub struct CreateEditRequest {
     pub top_p: Option<f32>, // min: 0, max: 1, default: 1
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
 pub struct CreateEditResponse {
     pub object: String,
@@ -220,6 +225,7 @@ pub struct CreateEditResponse {
     pub usage: Usage,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Default, Debug, Serialize, Clone, Copy, PartialEq)]
 pub enum ImageSize {
     #[serde(rename = "256x256")]
@@ -231,6 +237,7 @@ pub enum ImageSize {
     S1024x1024,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Serialize, Default, Clone, Copy, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum ResponseFormat {
@@ -240,6 +247,7 @@ pub enum ResponseFormat {
     B64Json,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Clone, Serialize, Default, Builder, PartialEq)]
 #[builder(name = "CreateImageRequestArgs")]
 #[builder(pattern = "mutable")]
@@ -267,6 +275,7 @@ pub struct CreateImageRequest {
     pub user: Option<String>,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum ImageData {
@@ -275,17 +284,20 @@ pub enum ImageData {
     B64Json(std::sync::Arc<String>),
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct ImageResponse {
     pub created: u32,
     pub data: Vec<std::sync::Arc<ImageData>>,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct ImageInput {
     pub path: PathBuf,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Clone, Default, Builder, PartialEq)]
 #[builder(name = "CreateImageEditRequestArgs")]
 #[builder(pattern = "mutable")]
@@ -315,6 +327,7 @@ pub struct CreateImageEditRequest {
     pub user: Option<String>,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Default, Clone, Builder, PartialEq)]
 #[builder(name = "CreateImageVariationRequestArgs")]
 #[builder(pattern = "mutable")]
@@ -415,11 +428,13 @@ pub struct CreateModerationResponse {
     pub results: Vec<ContentModerationResult>,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct FileInput {
     pub path: PathBuf,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Default, Clone, Builder, PartialEq)]
 #[builder(name = "CreateFileRequestArgs")]
 #[builder(pattern = "mutable")]
@@ -438,12 +453,14 @@ pub struct CreateFileRequest {
     pub purpose: String,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
 pub struct ListFilesResponse {
     pub object: String,
     pub data: Vec<OpenAIFile>,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
 pub struct DeleteFileResponse {
     pub id: String,
@@ -451,6 +468,7 @@ pub struct DeleteFileResponse {
     pub deleted: bool,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct OpenAIFile {
     pub id: String,
@@ -463,6 +481,7 @@ pub struct OpenAIFile {
     pub status_details: Option<serde_json::Value>, // nullable: true
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Serialize, Clone, Default, Builder, PartialEq)]
 #[builder(name = "CreateFineTuneRequestArgs")]
 #[builder(pattern = "mutable")]
@@ -582,12 +601,14 @@ pub struct CreateFineTuneRequest {
     pub suffix: Option<String>, // default: null, minLength:1, maxLength:40
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
 pub struct ListFineTuneResponse {
     pub object: String,
     pub data: Vec<FineTune>,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct FineTune {
     pub id: String,
@@ -605,6 +626,7 @@ pub struct FineTune {
     pub events: Option<Vec<FineTuneEvent>>,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct FineTuneEvent {
     pub object: String,
@@ -613,18 +635,21 @@ pub struct FineTuneEvent {
     pub message: String,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
 pub struct ListFineTuneEventsResponse {
     pub object: String,
     pub data: Vec<FineTuneEvent>,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
 pub struct ListFineTuneEventsStreamResponse {
     pub object: String,
     pub data: Option<Vec<FineTuneEvent>>,
 }
 
+#[cfg(feature = "enable_tokio")]
 /// Parsed server side events stream until an \[DONE\] is received from server.
 pub type FineTuneEventsResponseStream =
     Pin<Box<dyn Stream<Item = Result<ListFineTuneEventsStreamResponse, OpenAIError>> + Send>>;
@@ -899,11 +924,13 @@ pub struct CreateChatCompletionStreamResponse {
     pub choices: Vec<ChatCompletionResponseStreamMessage>,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct AudioInput {
     pub path: PathBuf,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Serialize, Default, Clone, Copy, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum AudioResponseFormat {
@@ -915,6 +942,7 @@ pub enum AudioResponseFormat {
     Vtt,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Clone, Default, Debug, Builder, PartialEq)]
 #[builder(name = "CreateTranscriptionRequestArgs")]
 #[builder(pattern = "mutable")]
@@ -941,11 +969,13 @@ pub struct CreateTranscriptionRequest {
     pub language: Option<String>,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct CreateTranscriptionResponse {
     pub text: String,
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Clone, Default, Debug, Builder, PartialEq)]
 #[builder(name = "CreateTranslationRequestArgs")]
 #[builder(pattern = "mutable")]
@@ -969,6 +999,7 @@ pub struct CreateTranslationRequest {
     pub temperature: Option<f32>, // default: 0
 }
 
+#[cfg(feature = "enable_tokio")]
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
 pub struct CreateTranslationResponse {
     pub text: String,

--- a/async-openai/tests/boxed_future.rs
+++ b/async-openai/tests/boxed_future.rs
@@ -1,9 +1,11 @@
 use futures::future::{BoxFuture, FutureExt};
 use futures::StreamExt;
 
+#[cfg(feature = "enable_tokio")]
 use async_openai::types::{CompletionResponseStream, CreateCompletionRequestArgs};
 use async_openai::Client;
 
+#[cfg(feature = "enable_tokio")]
 #[tokio::test]
 async fn boxed_future_test() {
     fn interpret_bool(token_stream: &mut CompletionResponseStream) -> BoxFuture<'_, bool> {


### PR DESCRIPTION
This adds a feature gate for all functionalities that requires `tokio`, and it should pave the way to close #102. Adding the feature gate `enable_tokio` should not be a breaking change.

Please note that since I don't have an API key from OpenAI but from Azure OpenAI, I couldn't test if these changes break OpenAI functionalities, so please help me test them. Thanks!