### PR TITLE
add a struct to transform EventSource stream into OpenAI response stream

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -40,6 +40,7 @@ tracing = "0.1.37"
 derive_builder = "0.12.0"
 async-convert = "1.0.0"
 secrecy = { version = "0.8.0", features=["serde"] }
+pin-project-lite = "0.2"
 
 [dev-dependencies]
 tokio-test = "0.4.2"


### PR DESCRIPTION
Hey, this is my attempt to remove `tokio` in `stream()` to further resolve #102 . I think `pub(crate) async fn stream<O>` is basically doing stream transformation and early stopping, so I wrap the transformation into a struct instead.

I don't have time to test it yet (sorry about that), but it did compile lol, so this should be considered as a draft PR. If you can help test it, it'd be great. Thanks!