### PR TITLE
Expose `Config`

### DIFF
--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -110,6 +110,10 @@ impl<C: Config> Client<C> {
         Audio::new(self)
     }
 
+    pub fn config(&self) -> &C {
+        &self.config
+    }
+
     /// Make a GET request to {path} and deserialize the response body
     pub(crate) async fn get<O>(&self, path: &str) -> Result<O, OpenAIError>
     where


### PR DESCRIPTION
A good practice in production environments is to have multiple clients from multiple endpoints and api keys to increase reliability and throughput. But, managing these different clients can be hectic as some fail. Providing a way to debug more easily by exposing the config would be great. A workaround would be to wrap every client in a container with the config info, but it's not ideal.

This simply exposes `Config` parameter so we can do something like `client.config().api_base()`