### PR TITLE
Updates from latest upstream spec

### DIFF
--- a/async-openai/README.md
+++ b/async-openai/README.md
@@ -24,20 +24,23 @@
 - It's based on [OpenAI OpenAPI spec](https://github.com/openai/openai-openapi)
 - Current features:
   - [x] Audio
-  - [x] Chat (including SSE streaming)
-  - [x] Completions (including SSE streaming)
-  - [x] Edits
+  - [x] Chat
+  - [x] Completions (Legacy)
+  - [x] Edits (Deprecated)
   - [x] Embeddings
   - [x] Files
-  - [x] Fine-Tuning (including SSE streaming)
+  - [x] Fine-Tuning
+  - [x] Fine-Tunes (Deprecated)
   - [x] Images
-  - [x] Microsoft Azure Endpoints
+  - [x] Microsoft Azure OpenAI Service
   - [x] Models
   - [x] Moderations
+- Support SSE streaming on available APIs
 - All requests including form submissions (except SSE streaming) are retried with exponential backoff when [rate limited](https://platform.openai.com/docs/guides/rate-limits) by the API server.
-- Ergonomic Rust library with builder pattern for all request objects.
+- Ergonomic builder pattern for all request objects.
 
-**Note on Azure OpenAI Service**:  `async-openai` primarily implements OpenAI APIs, and exposes same library for Azure OpenAI Service too. In reality Azure OpenAI Service provides only subset of OpenAI APIs.
+**Note on Azure OpenAI Service (AOS)**:  `async-openai` primarily implements OpenAI spec, and doesn't try to maintain parity with spec of AOS.
+
 ## Usage
 
 The library reads [API key](https://platform.openai.com/account/api-keys) from the environment variable `OPENAI_API_KEY`.

--- a/async-openai/src/chat.rs
+++ b/async-openai/src/chat.rs
@@ -7,7 +7,9 @@ use crate::{
     Client,
 };
 
-/// Given a chat conversation, the model will return a chat completion response.
+/// Given a list of messages comprising a conversation, the model will return a response.
+///
+/// Related guide: [Chat completions](https://platform.openai.com/docs/guides/gpt)
 pub struct Chat<'c, C: Config> {
     client: &'c Client<C>,
 }
@@ -17,7 +19,7 @@ impl<'c, C: Config> Chat<'c, C> {
         Self { client }
     }
 
-    /// Creates a completion for the chat message
+    /// Creates a model response for the given chat conversation.
     pub async fn create(
         &self,
         request: CreateChatCompletionRequest,

--- a/async-openai/src/completion.rs
+++ b/async-openai/src/completion.rs
@@ -5,9 +5,12 @@ use crate::{
     types::{CompletionResponseStream, CreateCompletionRequest, CreateCompletionResponse},
 };
 
-/// Given a prompt, the model will return one or more predicted
-/// completions, and can also return the probabilities of alternative
-/// tokens at each position.
+/// Given a prompt, the model will return one or more predicted completions,
+/// and can also return the probabilities of alternative tokens at each position.
+/// We recommend most users use our Chat completions API.
+/// [Learn more](https://platform.openai.com/docs/deprecations/2023-07-06-gpt-and-embeddings)
+///
+/// Related guide: [Legacy Completions](https://platform.openai.com/docs/guides/gpt/completions-api)
 pub struct Completions<'c, C: Config> {
     client: &'c Client<C>,
 }

--- a/async-openai/src/file.rs
+++ b/async-openai/src/file.rs
@@ -5,7 +5,7 @@ use crate::{
     Client,
 };
 
-/// Files are used to upload documents that can be used with features like [Fine-tuning](https://platform.openai.com/docs/api-reference/fine-tunes).
+/// Files are used to upload documents that can be used with features like [Fine-tuning](https://platform.openai.com/docs/api-reference/fine-tuning).
 pub struct Files<'c, C: Config> {
     client: &'c Client<C>,
 }

--- a/async-openai/src/fine_tuning.rs
+++ b/async-openai/src/fine_tuning.rs
@@ -1,0 +1,83 @@
+use serde::Serialize;
+
+use crate::{
+    config::Config,
+    error::OpenAIError,
+    types::{
+        CreateFineTuningJobRequest, FineTuningJob, ListFineTuningJobEventsResponse,
+        ListPaginatedFineTuningJobsResponse,
+    },
+    Client,
+};
+
+/// Manage fine-tuning jobs to tailor a model to your specific training data.
+///
+/// Related guide: [Fine-tune models](https://platform.openai.com/docs/guides/fine-tuning)
+pub struct FineTuning<'c, C: Config> {
+    client: &'c Client<C>,
+}
+
+impl<'c, C: Config> FineTuning<'c, C> {
+    pub fn new(client: &'c Client<C>) -> Self {
+        Self { client }
+    }
+
+    /// Creates a job that fine-tunes a specified model from a given dataset.
+    ///
+    /// Response includes details of the enqueued job including job status and the name of the fine-tuned models once complete.
+    ///
+    /// [Learn more about Fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)
+    pub async fn create(
+        &self,
+        request: CreateFineTuningJobRequest,
+    ) -> Result<FineTuningJob, OpenAIError> {
+        self.client.post("/fine_tuning/jobs", request).await
+    }
+
+    /// List your organization's fine-tuning jobs
+    pub async fn list_paginated<Q>(
+        &self,
+        query: &Q,
+    ) -> Result<ListPaginatedFineTuningJobsResponse, OpenAIError>
+    where
+        Q: Serialize + ?Sized,
+    {
+        self.client.get_with_query("/fine_tuning/jobs", query).await
+    }
+
+    /// Gets info about the fine-tune job.
+    ///
+    /// [Learn more about Fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)
+    pub async fn retrieve(&self, fine_tuning_job_id: &str) -> Result<FineTuningJob, OpenAIError> {
+        self.client
+            .get(format!("/fine_tuning/jobs/{fine_tuning_job_id}").as_str())
+            .await
+    }
+
+    /// Immediately cancel a fine-tune job.
+    pub async fn cancel(&self, fine_tuning_job_id: &str) -> Result<FineTuningJob, OpenAIError> {
+        self.client
+            .post(
+                format!("/fine_tuning/jobs/{fine_tuning_job_id}/cancel").as_str(),
+                (),
+            )
+            .await
+    }
+
+    /// Get fine-grained status updates for a fine-tune job.
+    pub async fn list_events<Q>(
+        &self,
+        fine_tuning_job_id: &str,
+        query: &Q,
+    ) -> Result<ListFineTuningJobEventsResponse, OpenAIError>
+    where
+        Q: Serialize + ?Sized,
+    {
+        self.client
+            .get_with_query(
+                format!("/fine_tuning/jobs/{fine_tuning_job_id}/events").as_str(),
+                query,
+            )
+            .await
+    }
+}

--- a/async-openai/src/image.rs
+++ b/async-openai/src/image.rs
@@ -2,14 +2,14 @@ use crate::{
     config::Config,
     error::OpenAIError,
     types::{
-        CreateImageEditRequest, CreateImageRequest, CreateImageVariationRequest, ImageResponse,
+        CreateImageEditRequest, CreateImageRequest, CreateImageVariationRequest, ImagesResponse,
     },
     Client,
 };
 
 /// Given a prompt and/or an input image, the model will generate a new image.
 ///
-/// Related guide: [Image generation](https://platform.openai.com/docs/guides/images/introduction)
+/// Related guide: [Image generation](https://platform.openai.com/docs/guides/images)
 pub struct Images<'c, C: Config> {
     client: &'c Client<C>,
 }
@@ -20,7 +20,7 @@ impl<'c, C: Config> Images<'c, C> {
     }
 
     /// Creates an image given a prompt.
-    pub async fn create(&self, request: CreateImageRequest) -> Result<ImageResponse, OpenAIError> {
+    pub async fn create(&self, request: CreateImageRequest) -> Result<ImagesResponse, OpenAIError> {
         self.client.post("/images/generations", request).await
     }
 
@@ -28,7 +28,7 @@ impl<'c, C: Config> Images<'c, C> {
     pub async fn create_edit(
         &self,
         request: CreateImageEditRequest,
-    ) -> Result<ImageResponse, OpenAIError> {
+    ) -> Result<ImagesResponse, OpenAIError> {
         self.client.post_form("/images/edits", request).await
     }
 
@@ -36,7 +36,7 @@ impl<'c, C: Config> Images<'c, C> {
     pub async fn create_variation(
         &self,
         request: CreateImageVariationRequest,
-    ) -> Result<ImageResponse, OpenAIError> {
+    ) -> Result<ImagesResponse, OpenAIError> {
         self.client.post_form("/images/variations", request).await
     }
 }

--- a/async-openai/src/lib.rs
+++ b/async-openai/src/lib.rs
@@ -82,11 +82,14 @@ mod client;
 mod completion;
 pub mod config;
 mod download;
+#[deprecated(since = "0.15.0", note = "By OpenAI")]
 mod edit;
 mod embedding;
 pub mod error;
 mod file;
+#[deprecated(since = "0.15.0", note = "By OpenAI")]
 mod fine_tune;
+mod fine_tuning;
 mod image;
 mod model;
 mod moderation;
@@ -101,6 +104,7 @@ pub use edit::Edits;
 pub use embedding::Embeddings;
 pub use file::Files;
 pub use fine_tune::FineTunes;
+pub use fine_tuning::FineTuning;
 pub use image::Images;
 pub use model::Models;
 pub use moderation::Moderations;

--- a/async-openai/src/moderation.rs
+++ b/async-openai/src/moderation.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// Given a input text, outputs if the model classifies it as violating OpenAI's content policy.
 ///
-/// Related guide: [Moderations](https://platform.openai.com/docs/guides/moderation/overview)
+/// Related guide: [Moderations](https://platform.openai.com/docs/guides/moderation)
 pub struct Moderations<'c, C: Config> {
     client: &'c Client<C>,
 }

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -12,8 +12,8 @@ use crate::{
 use super::{
     AudioInput, AudioResponseFormat, ChatCompletionFunctionCall, CreateFileRequest,
     CreateImageEditRequest, CreateImageVariationRequest, CreateTranscriptionRequest,
-    CreateTranslationRequest, EmbeddingInput, FileInput, ImageData, ImageInput, ImageResponse,
-    ImageSize, ModerationInput, Prompt, ResponseFormat, Role, Stop,
+    CreateTranslationRequest, EmbeddingInput, FileInput, Image, ImageInput, ImageSize,
+    ImagesResponse, ModerationInput, Prompt, ResponseFormat, Role, Stop,
 };
 
 macro_rules! impl_from {
@@ -152,7 +152,7 @@ impl Display for Role {
     }
 }
 
-impl ImageResponse {
+impl ImagesResponse {
     /// Save each image in a dedicated Tokio task and return paths to saved files.
     /// For [ResponseFormat::Url] each file is downloaded in dedicated Tokio task.
     pub async fn save<P: AsRef<Path>>(&self, dir: P) -> Result<Vec<PathBuf>, OpenAIError> {
@@ -200,11 +200,11 @@ impl ImageResponse {
     }
 }
 
-impl ImageData {
+impl Image {
     async fn save<P: AsRef<Path>>(&self, dir: P) -> Result<PathBuf, OpenAIError> {
         match self {
-            ImageData::Url(url) => download_url(url, dir).await,
-            ImageData::B64Json(b64_json) => save_b64(b64_json, dir).await,
+            Image::Url(url) => download_url(url, dir).await,
+            Image::B64Json(b64_json) => save_b64(b64_json, dir).await,
         }
     }
 }
@@ -351,14 +351,11 @@ impl_from_for_array_of_integer_array!(u16, Prompt);
 
 impl From<&str> for ChatCompletionFunctionCall {
     fn from(value: &str) -> Self {
-        match value {
-            "none" => Self::None,
-            "auto" => Self::Auto,
-            _ => Self::Function { name: value.to_string() },
+        match value.to_lowercase().as_str() {
+            "auto" => ChatCompletionFunctionCall::Auto,
+            "none" => ChatCompletionFunctionCall::None,
+            _ => ChatCompletionFunctionCall::Function { name: value.into() },
         }
-    }
-}
-
     }
 }
 

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -352,9 +352,9 @@ impl_from_for_array_of_integer_array!(u16, Prompt);
 impl From<&str> for ChatCompletionFunctionCall {
     fn from(value: &str) -> Self {
         match value.to_lowercase().as_str() {
-            "auto" => ChatCompletionFunctionCall::Auto,
-            "none" => ChatCompletionFunctionCall::None,
-            _ => ChatCompletionFunctionCall::Function { name: value.into() },
+            "auto" => Self::Auto,
+            "none" => Self::None,
+            _ => Self::Function { name: value.into() },
         }
     }
 }

--- a/examples/function-call-stream/src/main.rs
+++ b/examples/function-call-stream/src/main.rs
@@ -2,10 +2,11 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::io::{stdout, Write};
 
+use async_openai::types::FinishReason;
 use async_openai::{
     types::{
         ChatCompletionFunctionsArgs, ChatCompletionRequestMessageArgs,
-        CreateChatCompletionRequestArgs, FinishReason, Role,
+        CreateChatCompletionRequestArgs, Role,
     },
     Client,
 };
@@ -62,8 +63,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             fn_args.push_str(args);
                         }
                     }
-                    if let Some(finish_reason) = chat_choice.finish_reason {
-                        if finish_reason == FinishReason::FunctionCall {
+                    if let Some(finish_reason) = &chat_choice.finish_reason {
+                        if matches!(finish_reason, FinishReason::FunctionCall) {
                             call_fn(&client, &fn_name, &fn_args).await?;
                         }
                     } else if let Some(content) = &chat_choice.delta.content {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,130 +1,49 @@
 openapi: 3.0.0
 info:
   title: OpenAI API
-  description: APIs for sampling from and fine-tuning language models
-  version: "1.3.0"
+  description: The OpenAI REST API. Please see https://platform.openai.com/docs/api-reference for more details.
+  version: "2.0.0"
+  termsOfService: https://openai.com/policies/terms-of-use
+  contact:
+    name: OpenAI Support
+    url: https://help.openai.com/
+  license:
+    name: MIT
+    url: https://github.com/openai/openai-openapi/blob/master/LICENSE
 servers:
   - url: https://api.openai.com/v1
 tags:
-  - name: OpenAI
-    description: The OpenAI REST API
+  - name: Audio
+    description: Learn how to turn audio into text.
+  - name: Chat
+    description: Given a list of messages comprising a conversation, the model will return a response.
+  - name: Completions
+    description: Given a prompt, the model will return one or more predicted completions, and can also return the probabilities of alternative tokens at each position.
+  - name: Embeddings
+    description: Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.
+  - name: Fine-tuning
+    description: Manage fine-tuning jobs to tailor a model to your specific training data.
+  - name: Files
+    description: Files are used to upload documents that can be used with features like fine-tuning.
+  - name: Images
+    description: Given a prompt and/or an input image, the model will generate a new image.
+  - name: Models
+    description: List and describe the various models available in the API.
+  - name: Moderations
+    description: Given a input text, outputs if the model classifies it as violating OpenAI's content policy.
+  - name: Fine-tunes
+    description: Manage legacy fine-tuning jobs to tailor a model to your specific training data.
+  - name: Edits
+    description: Given a prompt and an instruction, the model will return an edited version of the prompt.
+  
 paths:
-  /engines:
-    get:
-      operationId: listEngines
-      deprecated: true
-      tags:
-        - OpenAI
-      summary: Lists the currently available (non-finetuned) models, and provides basic information about each one such as the owner and availability.
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ListEnginesResponse"
-      x-oaiMeta:
-        name: List engines
-        group: engines
-        path: list
-        examples:
-          curl: |
-            curl https://api.openai.com/v1/engines \
-              -H "Authorization: Bearer $OPENAI_API_KEY"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Engine.list()
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.listEngines();
-        response: |
-          {
-            "data": [
-              {
-                "id": "engine-id-0",
-                "object": "engine",
-                "owner": "organization-owner",
-                "ready": true
-              },
-              {
-                "id": "engine-id-2",
-                "object": "engine",
-                "owner": "organization-owner",
-                "ready": true
-              },
-              {
-                "id": "engine-id-3",
-                "object": "engine",
-                "owner": "openai",
-                "ready": false
-              },
-            ],
-            "object": "list"
-          }
-
-  /engines/{engine_id}:
-    get:
-      operationId: retrieveEngine
-      deprecated: true
-      tags:
-        - OpenAI
-      summary: Retrieves a model instance, providing basic information about it such as the owner and availability.
-      parameters:
-        - in: path
-          name: engine_id
-          required: true
-          schema:
-            type: string
-            # ideally this will be an actual ID, so this will always work from browser
-            example: davinci
-          description: &engine_id_description >
-            The ID of the engine to use for this request
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Engine"
-      x-oaiMeta:
-        name: Retrieve engine
-        group: engines
-        path: retrieve
-        examples:
-          curl: |
-            curl https://api.openai.com/v1/engines/VAR_model_id \
-              -H "Authorization: Bearer $OPENAI_API_KEY"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Engine.retrieve("VAR_model_id")
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.retrieveEngine("VAR_model_id");
-        response: |
-          {
-            "id": "VAR_model_id",
-            "object": "engine",
-            "owner": "openai",
-            "ready": true
-          }
-
+  # Note: When adding an endpoint, make sure you also add it in the `groups` section, in the end of this file,
+  # under the appropriate group
   /chat/completions:
     post:
       operationId: createChatCompletion
       tags:
-        - OpenAI
+        - Chat
       summary: Creates a model response for the given chat conversation.
       requestBody:
         required: true
@@ -143,73 +62,284 @@ paths:
       x-oaiMeta:
         name: Create chat completion
         group: chat
+        returns: |
+          Returns a [chat completion](/docs/api-reference/chat/object) object, or a streamed sequence of [chat completion chunk](/docs/api-reference/chat/streaming) objects if the request is streamed.
         path: create
-        beta: true
         examples:
-          curl: |
-            curl https://api.openai.com/v1/chat/completions \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -d '{
-                "model": "gpt-3.5-turbo",
-                "messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Hello!"}]
-              }'
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
+          - title: No Streaming
+            request:
+              curl: |
+                curl https://api.openai.com/v1/chat/completions \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "model": "VAR_model_id",
+                    "messages": [
+                      {
+                        "role": "system",
+                        "content": "You are a helpful assistant."
+                      },
+                      {
+                        "role": "user",
+                        "content": "Hello!"
+                      }
+                    ]
+                  }'
+              python: |
+                import os
+                import openai
+                openai.api_key = os.getenv("OPENAI_API_KEY")
 
-            completion = openai.ChatCompletion.create(
-              model="gpt-3.5-turbo",
-              messages=[
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": "Hello!"}
-              ]
-            )
+                completion = openai.ChatCompletion.create(
+                  model="VAR_model_id",
+                  messages=[
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "Hello!"}
+                  ]
+                )
 
-            print(completion.choices[0].message)
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
+                print(completion.choices[0].message)
+              node.js: |-
+                import OpenAI from "openai";
 
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
+                const openai = new OpenAI();
 
-            const completion = await openai.createChatCompletion({
-              model: "gpt-3.5-turbo",
-              messages: [{"role": "system", "content": "You are a helpful assistant."}, {role: "user", content: "Hello world"}],
-            });
-            console.log(completion.data.choices[0].message);
-        parameters: |
-          {
-            "model": "gpt-3.5-turbo",
-            "messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Hello!"}]
-          }
-        response: |
-          {
-            "id": "chatcmpl-123",
-            "object": "chat.completion",
-            "created": 1677652288,
-            "choices": [{
-              "index": 0,
-              "message": {
-                "role": "assistant",
-                "content": "\n\nHello there, how may I assist you today?",
-              },
-              "finish_reason": "stop"
-            }],
-            "usage": {
-              "prompt_tokens": 9,
-              "completion_tokens": 12,
-              "total_tokens": 21
-            }
-          }
+                async function main() {
+                  const completion = await openai.chat.completions.create({
+                    messages: [{ role: "system", content: "You are a helpful assistant." }],
+                    model: "VAR_model_id",
+                  });
+
+                  console.log(completion.choices[0]);
+                }
+
+                main();
+            response: &chat_completion_example |
+              {
+                "id": "chatcmpl-123",
+                "object": "chat.completion",
+                "created": 1677652288,
+                "model": "gpt-3.5-turbo-0613",
+                "choices": [{
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": "\n\nHello there, how may I assist you today?",
+                  },
+                  "finish_reason": "stop"
+                }],
+                "usage": {
+                  "prompt_tokens": 9,
+                  "completion_tokens": 12,
+                  "total_tokens": 21
+                }
+              }
+          - title: Streaming
+            request:
+              curl: |
+                curl https://api.openai.com/v1/chat/completions \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "model": "VAR_model_id",
+                    "messages": [
+                      {
+                        "role": "system",
+                        "content": "You are a helpful assistant."
+                      },
+                      {
+                        "role": "user",
+                        "content": "Hello!"
+                      }
+                    ],
+                    "stream": true
+                  }'
+              python: |
+                import os
+                import openai
+                openai.api_key = os.getenv("OPENAI_API_KEY")
+
+                completion = openai.ChatCompletion.create(
+                  model="VAR_model_id",
+                  messages=[
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "Hello!"}
+                  ],
+                  stream=True
+                )
+
+                for chunk in completion:
+                  print(chunk.choices[0].delta)
+
+              node.js: |-
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const completion = await openai.chat.completions.create({
+                    model: "VAR_model_id",
+                    messages: [
+                      {"role": "system", "content": "You are a helpful assistant."},
+                      {"role": "user", "content": "Hello!"}
+                    ],
+                    stream: true,
+                  });
+
+                  for await (const chunk of completion) {
+                    console.log(chunk.choices[0].delta.content);
+                  }
+                }
+
+                main();
+            response: &chat_completion_chunk_example |
+              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
+
+              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
+
+              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":null}]}
+
+              ....
+
+              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" today"},"finish_reason":null}]}
+
+              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"?"},"finish_reason":null}]}
+
+              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+          - title: Function calling
+            request:
+              curl: |
+                curl https://api.openai.com/v1/chat/completions \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -d '{
+                  "model": "gpt-3.5-turbo",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "What is the weather like in Boston?"
+                    }
+                  ],
+                  "functions": [
+                    {
+                      "name": "get_current_weather",
+                      "description": "Get the current weather in a given location",
+                      "parameters": {
+                        "type": "object",
+                        "properties": {
+                          "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "enum": ["celsius", "fahrenheit"]
+                          }
+                        },
+                        "required": ["location"]
+                      }
+                    }
+                  ],
+                  "function_call": "auto"
+                }'
+              python: |
+                import os
+                import openai
+                openai.api_key = os.getenv("OPENAI_API_KEY")
+
+                functions = [ 
+                  {
+                    "name": "get_current_weather",
+                    "description": "Get the current weather in a given location",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string",
+                                "description": "The city and state, e.g. San Francisco, CA",
+                            },
+                            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                        },
+                        "required": ["location"],
+                    },
+                  }
+                ]
+                messages = [{"role": "user", "content": "What's the weather like in Boston today?"}]
+                completion = openai.ChatCompletion.create(
+                  model="VAR_model_id",
+                  messages=messages,
+                  functions=functions,
+                  function_call="auto",  # auto is default, but we'll be explicit
+                )
+
+                print(completion)
+
+              node.js: |-
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const messages = [{"role": "user", "content": "What's the weather like in Boston today?"}];
+                  const functions = [
+                      {
+                          "name": "get_current_weather",
+                          "description": "Get the current weather in a given location",
+                          "parameters": {
+                              "type": "object",
+                              "properties": {
+                                  "location": {
+                                      "type": "string",
+                                      "description": "The city and state, e.g. San Francisco, CA",
+                                  },
+                                  "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                              },
+                              "required": ["location"],
+                          },
+                      }
+                  ];
+
+                  const response = await openai.chat.completions.create({
+                      model: "gpt-3.5-turbo",
+                      messages: messages,
+                      functions: functions,
+                      function_call: "auto",  // auto is default, but we'll be explicit
+                  });
+
+                  console.log(response);
+                }
+
+                main();
+            response: &chat_completion_function_example |
+              {
+                "choices": [
+                  {
+                    "finish_reason": "function_call",
+                    "index": 0,
+                    "message": {
+                      "content": null,
+                      "function_call": {
+                        "arguments": "{\n  \"location\": \"Boston, MA\"\n}",
+                        "name": "get_current_weather"
+                      },
+                      "role": "assistant"
+                    }
+                  }
+                ],
+                "created": 1694028367,
+                "model": "gpt-3.5-turbo-0613",
+                "object": "chat.completion",
+                "usage": {
+                  "completion_tokens": 18,
+                  "prompt_tokens": 82,
+                  "total_tokens": 100
+                }
+              }
   /completions:
     post:
       operationId: createCompletion
       tags:
-        - OpenAI
+        - Completions
       summary: Creates a completion for the provided prompt and parameters.
       requestBody:
         required: true
@@ -226,78 +356,131 @@ paths:
                 $ref: "#/components/schemas/CreateCompletionResponse"
       x-oaiMeta:
         name: Create completion
-        group: completions
-        path: create
+        returns: |
+          Returns a [completion](/docs/api-reference/completions/object) object, or a sequence of completion objects if the request is streamed.
+        legacy: true
         examples:
-          curl: |
-            curl https://api.openai.com/v1/completions \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -d '{
-                "model": "VAR_model_id",
-                "prompt": "Say this is a test",
-                "max_tokens": 7,
-                "temperature": 0
-              }'
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Completion.create(
-              model="VAR_model_id",
-              prompt="Say this is a test",
-              max_tokens=7,
-              temperature=0
-            )
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.createCompletion({
-              model: "VAR_model_id",
-              prompt: "Say this is a test",
-              max_tokens: 7,
-              temperature: 0,
-            });
-        parameters: |
-          {
-            "model": "VAR_model_id",
-            "prompt": "Say this is a test",
-            "max_tokens": 7,
-            "temperature": 0,
-            "top_p": 1,
-            "n": 1,
-            "stream": false,
-            "logprobs": null,
-            "stop": "\n"
-          }
-        response: |
-          {
-            "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
-            "object": "text_completion",
-            "created": 1589478378,
-            "model": "VAR_model_id",
-            "choices": [
+          - title: No streaming
+            request:
+              curl: |
+                curl https://api.openai.com/v1/completions \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "model": "VAR_model_id",
+                    "prompt": "Say this is a test",
+                    "max_tokens": 7,
+                    "temperature": 0
+                  }'
+              python: |
+                import os
+                import openai
+                openai.api_key = os.getenv("OPENAI_API_KEY")
+                openai.Completion.create(
+                  model="VAR_model_id",
+                  prompt="Say this is a test",
+                  max_tokens=7,
+                  temperature=0
+                )
+              node.js: |-
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const completion = await openai.completions.create({
+                    model: "VAR_model_id",
+                    prompt: "Say this is a test.",
+                    max_tokens: 7,
+                    temperature: 0,
+                  });
+
+                  console.log(completion);
+                }
+                main();
+            response: |
               {
-                "text": "\n\nThis is indeed a test",
-                "index": 0,
-                "logprobs": null,
-                "finish_reason": "length"
+                "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
+                "object": "text_completion",
+                "created": 1589478378,
+                "model": "VAR_model_id",
+                "choices": [
+                  {
+                    "text": "\n\nThis is indeed a test",
+                    "index": 0,
+                    "logprobs": null,
+                    "finish_reason": "length"
+                  }
+                ],
+                "usage": {
+                  "prompt_tokens": 5,
+                  "completion_tokens": 7,
+                  "total_tokens": 12
+                }
               }
-            ],
-            "usage": {
-              "prompt_tokens": 5,
-              "completion_tokens": 7,
-              "total_tokens": 12
-            }
-          }
+          - title: Streaming
+            request:
+              curl: |
+                curl https://api.openai.com/v1/completions \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "model": "VAR_model_id",
+                    "prompt": "Say this is a test",
+                    "max_tokens": 7,
+                    "temperature": 0,
+                    "stream": true
+                  }'
+              python: |
+                import os
+                import openai
+                openai.api_key = os.getenv("OPENAI_API_KEY")
+                for chunk in openai.Completion.create(
+                  model="VAR_model_id",
+                  prompt="Say this is a test",
+                  max_tokens=7,
+                  temperature=0,
+                  stream=True
+                ):
+                  print(chunk['choices'][0]['text'])
+              node.js: |-
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const stream = await openai.completions.create({
+                    model: "VAR_model_id",
+                    prompt: "Say this is a test.",
+                    stream: true,
+                  });
+
+                  for await (const chunk of stream) {
+                    console.log(chunk.choices[0].text)
+                  }
+                }
+                main();
+            response: |
+              {
+                "id": "cmpl-7iA7iJjj8V2zOkCGvWF2hAkDWBQZe",
+                "object": "text_completion",
+                "created": 1690759702,
+                "choices": [
+                  {
+                    "text": "This",
+                    "index": 0,
+                    "logprobs": null,
+                    "finish_reason": null
+                  }
+                ],
+                "model": "gpt-3.5-turbo-instruct"
+              }
   /edits:
     post:
       operationId: createEdit
+      deprecated: true
       tags:
-        - OpenAI
+        - Edits
       summary: Creates a new edit for the provided input, instruction, and parameters.
       requestBody:
         required: true
@@ -314,66 +497,67 @@ paths:
                 $ref: "#/components/schemas/CreateEditResponse"
       x-oaiMeta:
         name: Create edit
+        returns: |
+          Returns an [edit](/docs/api-reference/edits/object) object.
         group: edits
-        path: create
         examples:
-          curl: |
-            curl https://api.openai.com/v1/edits \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -d '{
-                "model": "VAR_model_id",
-                "input": "What day of the wek is it?",
-                "instruction": "Fix the spelling mistakes"
-              }'
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Edit.create(
-              model="VAR_model_id",
-              input="What day of the wek is it?",
-              instruction="Fix the spelling mistakes"
-            )
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.createEdit({
-              model: "VAR_model_id",
-              input: "What day of the wek is it?",
-              instruction: "Fix the spelling mistakes",
-            });
-        parameters: |
-          {
-            "model": "VAR_model_id",
-            "input": "What day of the wek is it?",
-            "instruction": "Fix the spelling mistakes",
-          }
-        response: |
-          {
-            "object": "edit",
-            "created": 1589478378,
-            "choices": [
-              {
-                "text": "What day of the week is it?",
-                "index": 0,
+          request:
+            curl: |
+              curl https://api.openai.com/v1/edits \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -d '{
+                  "model": "VAR_model_id",
+                  "input": "What day of the wek is it?",
+                  "instruction": "Fix the spelling mistakes"
+                }'
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.Edit.create(
+                model="VAR_model_id",
+                input="What day of the wek is it?",
+                instruction="Fix the spelling mistakes"
+              )
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const edit = await openai.edits.create({
+                  model: "VAR_model_id",
+                  input: "What day of the wek is it?",
+                  instruction: "Fix the spelling mistakes.",
+                });
+
+                console.log(edit);
               }
-            ],
-            "usage": {
-              "prompt_tokens": 25,
-              "completion_tokens": 32,
-              "total_tokens": 57
+
+              main();
+          response: &edit_example |
+            {
+              "object": "edit",
+              "created": 1589478378,
+              "choices": [
+                {
+                  "text": "What day of the week is it?",
+                  "index": 0,
+                }
+              ],
+              "usage": {
+                "prompt_tokens": 25,
+                "completion_tokens": 32,
+                "total_tokens": 57
+              }
             }
-          }
 
   /images/generations:
     post:
       operationId: createImage
       tags:
-        - OpenAI
+        - Images
       summary: Creates an image given a prompt.
       requestBody:
         required: true
@@ -390,63 +574,56 @@ paths:
                 $ref: "#/components/schemas/ImagesResponse"
       x-oaiMeta:
         name: Create image
-        group: images
-        path: create
-        beta: true
+        returns: Returns a list of [image](/docs/api-reference/images/object) objects.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/images/generations \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -d '{
-                "prompt": "A cute baby sea otter",
-                "n": 2,
-                "size": "1024x1024"
-              }'
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Image.create(
-              prompt="A cute baby sea otter",
-              n=2,
-              size="1024x1024"
-            )
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.createImage({
-              prompt: "A cute baby sea otter",
-              n: 2,
-              size: "1024x1024",
-            });
-        parameters: |
-          {
-            "prompt": "A cute baby sea otter",
-            "n": 2,
-            "size": "1024x1024"
-          }
-        response: |
-          {
-            "created": 1589478378,
-            "data": [
-              {
-                "url": "https://..."
-              },
-              {
-                "url": "https://..."
+          request:
+            curl: |
+              curl https://api.openai.com/v1/images/generations \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -d '{
+                  "prompt": "A cute baby sea otter",
+                  "n": 2,
+                  "size": "1024x1024"
+                }'
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.Image.create(
+                prompt="A cute baby sea otter",
+                n=2,
+                size="1024x1024"
+              )
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const image = await openai.images.generate({ prompt: "A cute baby sea otter" });
+
+                console.log(image.data);
               }
-            ]
-          }
+              main();
+          response: |
+            {
+              "created": 1589478378,
+              "data": [
+                {
+                  "url": "https://..."
+                },
+                {
+                  "url": "https://..."
+                }
+              ]
+            }
 
   /images/edits:
     post:
       operationId: createImageEdit
       tags:
-        - OpenAI
+        - Images
       summary: Creates an edited or extended image given an original image and a prompt.
       requestBody:
         required: true
@@ -463,60 +640,62 @@ paths:
                 $ref: "#/components/schemas/ImagesResponse"
       x-oaiMeta:
         name: Create image edit
-        group: images
-        path: create-edit
-        beta: true
+        returns: Returns a list of [image](/docs/api-reference/images/object) objects.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/images/edits \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -F image="@otter.png" \
-              -F mask="@mask.png" \
-              -F prompt="A cute baby sea otter wearing a beret" \
-              -F n=2 \
-              -F size="1024x1024"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Image.create_edit(
-              image=open("otter.png", "rb"),
-              mask=open("mask.png", "rb"),
-              prompt="A cute baby sea otter wearing a beret",
-              n=2,
-              size="1024x1024"
-            )
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.createImageEdit(
-              fs.createReadStream("otter.png"),
-              fs.createReadStream("mask.png"),
-              "A cute baby sea otter wearing a beret",
-              2,
-              "1024x1024"
-            );
-        response: |
-          {
-            "created": 1589478378,
-            "data": [
-              {
-                "url": "https://..."
-              },
-              {
-                "url": "https://..."
+          request:
+            curl: |
+              curl https://api.openai.com/v1/images/edits \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -F image="@otter.png" \
+                -F mask="@mask.png" \
+                -F prompt="A cute baby sea otter wearing a beret" \
+                -F n=2 \
+                -F size="1024x1024"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.Image.create_edit(
+                image=open("otter.png", "rb"),
+                mask=open("mask.png", "rb"),
+                prompt="A cute baby sea otter wearing a beret",
+                n=2,
+                size="1024x1024"
+              )
+            node.js: |-
+              import fs from "fs";
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const image = await openai.images.edit({
+                  image: fs.createReadStream("otter.png"),
+                  mask: fs.createReadStream("mask.png"),
+                  prompt: "A cute baby sea otter wearing a beret",
+                });
+
+                console.log(image.data);
               }
-            ]
-          }
+              main();
+          response: |
+            {
+              "created": 1589478378,
+              "data": [
+                {
+                  "url": "https://..."
+                },
+                {
+                  "url": "https://..."
+                }
+              ]
+            }
 
   /images/variations:
     post:
       operationId: createImageVariation
       tags:
-        - OpenAI
+        - Images
       summary: Creates a variation of a given image.
       requestBody:
         required: true
@@ -533,54 +712,56 @@ paths:
                 $ref: "#/components/schemas/ImagesResponse"
       x-oaiMeta:
         name: Create image variation
-        group: images
-        path: create-variation
-        beta: true
+        returns: Returns a list of [image](/docs/api-reference/images/object) objects.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/images/variations \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -F image="@otter.png" \
-              -F n=2 \
-              -F size="1024x1024"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Image.create_variation(
-              image=open("otter.png", "rb"),
-              n=2,
-              size="1024x1024"
-            )
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.createImageVariation(
-              fs.createReadStream("otter.png"),
-              2,
-              "1024x1024"
-            );
-        response: |
-          {
-            "created": 1589478378,
-            "data": [
-              {
-                "url": "https://..."
-              },
-              {
-                "url": "https://..."
+          request:
+            curl: |
+              curl https://api.openai.com/v1/images/variations \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -F image="@otter.png" \
+                -F n=2 \
+                -F size="1024x1024"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.Image.create_variation(
+                image=open("otter.png", "rb"),
+                n=2,
+                size="1024x1024"
+              )
+            node.js: |-
+              import fs from "fs";
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const image = await openai.images.createVariation({
+                  image: fs.createReadStream("otter.png"),
+                });
+
+                console.log(image.data);
               }
-            ]
-          }
+              main();
+          response: |
+            {
+              "created": 1589478378,
+              "data": [
+                {
+                  "url": "https://..."
+                },
+                {
+                  "url": "https://..."
+                }
+              ]
+            }
 
   /embeddings:
     post:
       operationId: createEmbedding
       tags:
-        - OpenAI
+        - Embeddings
       summary: Creates an embedding vector representing the input text.
       requestBody:
         required: true
@@ -597,67 +778,70 @@ paths:
                 $ref: "#/components/schemas/CreateEmbeddingResponse"
       x-oaiMeta:
         name: Create embeddings
-        group: embeddings
-        path: create
+        returns: A list of [embedding](/docs/api-reference/embeddings/object) objects.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/embeddings \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d '{
-                "input": "The food was delicious and the waiter...",
-                "model": "text-embedding-ada-002"
-              }'
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Embedding.create(
-              model="text-embedding-ada-002",
-              input="The food was delicious and the waiter..."
-            )
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.createEmbedding({
-              model: "text-embedding-ada-002",
-              input: "The food was delicious and the waiter...",
-            });
-        parameters: |
-          {
-            "model": "text-embedding-ada-002",
-            "input": "The food was delicious and the waiter..."
-          }
-        response: |
-          {
-            "object": "list",
-            "data": [
-              {
-                "object": "embedding",
-                "embedding": [
-                  0.0023064255,
-                  -0.009327292,
-                  .... (1536 floats total for ada-002)
-                  -0.0028842222,
-                ],
-                "index": 0
+          request:
+            curl: |
+              curl https://api.openai.com/v1/embeddings \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                  "input": "The food was delicious and the waiter...",
+                  "model": "text-embedding-ada-002",
+                  "encoding_format": "float"
+                }'
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.Embedding.create(
+                model="text-embedding-ada-002",
+                input="The food was delicious and the waiter...",
+                encoding_format="float"
+              )
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const embedding = await openai.embeddings.create({
+                  model: "text-embedding-ada-002",
+                  input: "The quick brown fox jumped over the lazy dog",
+                  encoding_format: "float",
+                });
+
+                console.log(embedding);
               }
-            ],
-            "model": "text-embedding-ada-002",
-            "usage": {
-              "prompt_tokens": 8,
-              "total_tokens": 8
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "object": "embedding",
+                  "embedding": [
+                    0.0023064255,
+                    -0.009327292,
+                    .... (1536 floats total for ada-002)
+                    -0.0028842222,
+                  ],
+                  "index": 0
+                }
+              ],
+              "model": "text-embedding-ada-002",
+              "usage": {
+                "prompt_tokens": 8,
+                "total_tokens": 8
+              }
             }
-          }
 
   /audio/transcriptions:
     post:
       operationId: createTranscription
       tags:
-        - OpenAI
+        - Audio
       summary: Transcribes audio into the input language.
       requestBody:
         required: true
@@ -674,48 +858,47 @@ paths:
                 $ref: "#/components/schemas/CreateTranscriptionResponse"
       x-oaiMeta:
         name: Create transcription
-        group: audio
-        path: create
-        beta: true
+        returns: The transcriped text.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/audio/transcriptions \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -H "Content-Type: multipart/form-data" \
-              -F file="@/path/to/file/audio.mp3" \
-              -F model="whisper-1"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            audio_file = open("audio.mp3", "rb")
-            transcript = openai.Audio.transcribe("whisper-1", audio_file)
-          node: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const resp = await openai.createTranscription(
-              fs.createReadStream("audio.mp3"),
-              "whisper-1"
-            );
-        parameters: |
-          {
-            "file": "audio.mp3",
-            "model": "whisper-1"
-          }
-        response: |
-          {
-            "text": "Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that."
-          }
+          request:
+            curl: |
+              curl https://api.openai.com/v1/audio/transcriptions \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: multipart/form-data" \
+                -F file="@/path/to/file/audio.mp3" \
+                -F model="whisper-1"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              audio_file = open("audio.mp3", "rb")
+              transcript = openai.Audio.transcribe("whisper-1", audio_file)
+            node: |-
+              import fs from "fs";
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const transcription = await openai.audio.transcriptions.create({
+                  file: fs.createReadStream("audio.mp3"),
+                  model: "whisper-1",
+                });
+
+                console.log(transcription.text);
+              }
+              main();
+          response: |
+            {
+              "text": "Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that."
+            }
 
   /audio/translations:
     post:
       operationId: createTranslation
       tags:
-        - OpenAI
-      summary: Translates audio into into English.
+        - Audio
+      summary: Translates audio into English.
       requestBody:
         required: true
         content:
@@ -731,142 +914,41 @@ paths:
                 $ref: "#/components/schemas/CreateTranslationResponse"
       x-oaiMeta:
         name: Create translation
-        group: audio
-        path: create
-        beta: true
+        returns: The translated text.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/audio/translations \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -H "Content-Type: multipart/form-data" \
-              -F file="@/path/to/file/german.m4a" \
-              -F model="whisper-1"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            audio_file = open("german.m4a", "rb")
-            transcript = openai.Audio.translate("whisper-1", audio_file)
-          node: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const resp = await openai.createTranslation(
-              fs.createReadStream("audio.mp3"),
-              "whisper-1"
-            );
-        parameters: |
-          {
-            "file": "german.m4a",
-            "model": "whisper-1"
-          }
-        response: |
-          {
-            "text": "Hello, my name is Wolfgang and I come from Germany. Where are you heading today?"
-          }
-
-  /engines/{engine_id}/search:
-    post:
-      operationId: createSearch
-      deprecated: true
-      tags:
-        - OpenAI
-      summary: |
-        The search endpoint computes similarity scores between provided query and documents. Documents can be passed directly to the API if there are no more than 200 of them.
-
-        To go beyond the 200 document limit, documents can be processed offline and then used for efficient retrieval at query time. When `file` is set, the search endpoint searches over all the documents in the given file and returns up to the `max_rerank` number of documents. These documents will be returned along with their search scores.
-
-        The similarity score is a positive score that usually ranges from 0 to 300 (but can sometimes go higher), where a score above 200 usually means the document is semantically similar to the query.
-      parameters:
-        - in: path
-          name: engine_id
-          required: true
-          schema:
-            type: string
-            example: davinci
-          description: The ID of the engine to use for this request.  You can select one of `ada`, `babbage`, `curie`, or `davinci`.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateSearchRequest"
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CreateSearchResponse"
-      x-oaiMeta:
-        name: Create search
-        group: searches
-        path: create
-        examples:
-          curl: |
-            curl https://api.openai.com/v1/engines/davinci/search \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -d '{
-                "documents": ["White House", "hospital", "school"],
-                "query": "the president"
-              }'
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Engine("davinci").search(
-              documents=["White House", "hospital", "school"],
-              query="the president"
-            )
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.createSearch("davinci", {
-              documents: ["White House", "hospital", "school"],
-              query: "the president",
-            });
-        parameters: |
-          {
-            "documents": [
-              "White House",
-              "hospital",
-              "school"
-            ],
-            "query": "the president"
-          }
-        response: |
-          {
-            "data": [
-              {
-                "document": 0,
-                "object": "search_result",
-                "score": 215.412
-              },
-              {
-                "document": 1,
-                "object": "search_result",
-                "score": 40.316
-              },
-              {
-                "document": 2,
-                "object": "search_result",
-                "score":  55.226
-              }
-            ],
-            "object": "list"
-          }
+          request:
+            curl: |
+              curl https://api.openai.com/v1/audio/translations \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: multipart/form-data" \
+                -F file="@/path/to/file/german.m4a" \
+                -F model="whisper-1"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              audio_file = open("german.m4a", "rb")
+              transcript = openai.Audio.translate("whisper-1", audio_file)
+            node: |
+              const { Configuration, OpenAIApi } = require("openai");
+              const configuration = new Configuration({
+                apiKey: process.env.OPENAI_API_KEY,
+              });
+              const openai = new OpenAIApi(configuration);
+              const resp = await openai.createTranslation(
+                fs.createReadStream("audio.mp3"),
+                "whisper-1"
+              );
+          response: |
+            {
+              "text": "Hello, my name is Wolfgang and I come from Germany. Where are you heading today?"
+            }
 
   /files:
     get:
       operationId: listFiles
       tags:
-        - OpenAI
+        - Files
       summary: Returns a list of files that belong to the user's organization.
       responses:
         "200":
@@ -877,53 +959,59 @@ paths:
                 $ref: "#/components/schemas/ListFilesResponse"
       x-oaiMeta:
         name: List files
-        group: files
-        path: list
+        returns: A list of [file](/docs/api-reference/files/object) objects.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/files \
-              -H "Authorization: Bearer $OPENAI_API_KEY"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.File.list()
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.listFiles();
-        response: |
-          {
-            "data": [
-              {
-                "id": "file-ccdDZrC3iZVNiQVeEA6Z66wf",
-                "object": "file",
-                "bytes": 175,
-                "created_at": 1613677385,
-                "filename": "train.jsonl",
-                "purpose": "search"
-              },
-              {
-                "id": "file-XjGxS3KTG0uNmNOK362iJua3",
-                "object": "file",
-                "bytes": 140,
-                "created_at": 1613779121,
-                "filename": "puppy.jsonl",
-                "purpose": "search"
+          request:
+            curl: |
+              curl https://api.openai.com/v1/files \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.File.list()
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const list = await openai.files.list();
+
+                for await (const file of list) {
+                  console.log(file);
+                }
               }
-            ],
-            "object": "list"
-          }
+
+              main();
+          response: |
+            {
+              "data": [
+                {
+                  "id": "file-abc123",
+                  "object": "file",
+                  "bytes": 175,
+                  "created_at": 1613677385,
+                  "filename": "train.jsonl",
+                  "purpose": "search"
+                },
+                {
+                  "id": "file-abc123",
+                  "object": "file",
+                  "bytes": 140,
+                  "created_at": 1613779121,
+                  "filename": "puppy.jsonl",
+                  "purpose": "search"
+                }
+              ],
+              "object": "list"
+            }
     post:
       operationId: createFile
       tags:
-        - OpenAI
+        - Files
       summary: |
-        Upload a file that contains document(s) to be used across various endpoints/features. Currently, the size of all the files uploaded by one organization can be up to 1 GB. Please contact us if you need to increase the storage limit.
-
+        Upload a file that can be used across various endpoints/features. Currently, the size of all the files uploaded by one organization can be up to 1 GB. Please [contact us](https://help.openai.com/) if you need to increase the storage limit.
       requestBody:
         required: true
         content:
@@ -939,48 +1027,54 @@ paths:
                 $ref: "#/components/schemas/OpenAIFile"
       x-oaiMeta:
         name: Upload file
-        group: files
-        path: upload
+        returns: The uploaded [file](/docs/api-reference/files/object) object.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/files \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -F purpose="fine-tune" \
-              -F file="@mydata.jsonl"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.File.create(
-              file=open("mydata.jsonl", "rb"),
-              purpose='fine-tune'
-            )
-          node.js: |
-            const fs = require("fs");
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.createFile(
-              fs.createReadStream("mydata.jsonl"),
-              "fine-tune"
-            );
-        response: |
-          {
-            "id": "file-XjGxS3KTG0uNmNOK362iJua3",
-            "object": "file",
-            "bytes": 140,
-            "created_at": 1613779121,
-            "filename": "mydata.jsonl",
-            "purpose": "fine-tune"
-          }
+          request:
+            curl: |
+              curl https://api.openai.com/v1/files \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -F purpose="fine-tune" \
+                -F file="@mydata.jsonl"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.File.create(
+                file=open("mydata.jsonl", "rb"),
+                purpose='fine-tune'
+              )
+            node.js: |-
+              import fs from "fs";
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const file = await openai.files.create({
+                  file: fs.createReadStream("mydata.jsonl"),
+                  purpose: "fine-tune",
+                });
+
+                console.log(file);
+              }
+
+              main();
+          response: |
+            {
+              "id": "file-abc123",
+              "object": "file",
+              "bytes": 140,
+              "created_at": 1613779121,
+              "filename": "mydata.jsonl",
+              "purpose": "fine-tune",
+              "status": "uploaded" | "processed" | "pending" | "error"
+            }
 
   /files/{file_id}:
     delete:
       operationId: deleteFile
       tags:
-        - OpenAI
+        - Files
       summary: Delete a file.
       parameters:
         - in: path
@@ -988,7 +1082,7 @@ paths:
           required: true
           schema:
             type: string
-          description: The ID of the file to use for this request
+          description: The ID of the file to use for this request.
       responses:
         "200":
           description: OK
@@ -998,35 +1092,40 @@ paths:
                 $ref: "#/components/schemas/DeleteFileResponse"
       x-oaiMeta:
         name: Delete file
-        group: files
-        path: delete
+        returns: Deletion status.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/files/file-XjGxS3KTG0uNmNOK362iJua3 \
-              -X DELETE \
-              -H "Authorization: Bearer $OPENAI_API_KEY"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.File.delete("file-XjGxS3KTG0uNmNOK362iJua3")
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.deleteFile("file-XjGxS3KTG0uNmNOK362iJua3");
-        response: |
-          {
-            "id": "file-XjGxS3KTG0uNmNOK362iJua3",
-            "object": "file",
-            "deleted": true
-          }
+          request:
+            curl: |
+              curl https://api.openai.com/v1/files/file-abc123 \
+                -X DELETE \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.File.delete("file-abc123")
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const file = await openai.files.del("file-abc123");
+
+                console.log(file);
+              }
+
+              main();
+          response: |
+            {
+              "id": "file-abc123",
+              "object": "file",
+              "deleted": true
+            }
     get:
       operationId: retrieveFile
       tags:
-        - OpenAI
+        - Files
       summary: Returns information about a specific file.
       parameters:
         - in: path
@@ -1034,7 +1133,7 @@ paths:
           required: true
           schema:
             type: string
-          description: The ID of the file to use for this request
+          description: The ID of the file to use for this request.
       responses:
         "200":
           description: OK
@@ -1044,47 +1143,52 @@ paths:
                 $ref: "#/components/schemas/OpenAIFile"
       x-oaiMeta:
         name: Retrieve file
-        group: files
-        path: retrieve
+        returns: The [file](/docs/api-reference/files/object) object matching the specified ID.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/files/file-XjGxS3KTG0uNmNOK362iJua3 \
-              -H "Authorization: Bearer $OPENAI_API_KEY"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.File.retrieve("file-XjGxS3KTG0uNmNOK362iJua3")
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.retrieveFile("file-XjGxS3KTG0uNmNOK362iJua3");
-        response: |
-          {
-            "id": "file-XjGxS3KTG0uNmNOK362iJua3",
-            "object": "file",
-            "bytes": 140,
-            "created_at": 1613779657,
-            "filename": "mydata.jsonl",
-            "purpose": "fine-tune"
-          }
+          request:
+            curl: |
+              curl https://api.openai.com/v1/files/file-abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.File.retrieve("file-abc123")
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const file = await openai.files.retrieve("file-abc123");
+
+                console.log(file);
+              }
+
+              main();
+          response: |
+            {
+              "id": "file-abc123",
+              "object": "file",
+              "bytes": 140,
+              "created_at": 1613779657,
+              "filename": "mydata.jsonl",
+              "purpose": "fine-tune"
+            }
 
   /files/{file_id}/content:
     get:
       operationId: downloadFile
       tags:
-        - OpenAI
-      summary: Returns the contents of the specified file
+        - Files
+      summary: Returns the contents of the specified file.
       parameters:
         - in: path
           name: file_id
           required: true
           schema:
             type: string
-          description: The ID of the file to use for this request
+          description: The ID of the file to use for this request.
       responses:
         "200":
           description: OK
@@ -1094,259 +1198,498 @@ paths:
                 type: string
       x-oaiMeta:
         name: Retrieve file content
-        group: files
-        path: retrieve-content
+        returns: The file content.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/files/file-XjGxS3KTG0uNmNOK362iJua3/content \
-              -H "Authorization: Bearer $OPENAI_API_KEY" > file.jsonl
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            content = openai.File.download("file-XjGxS3KTG0uNmNOK362iJua3")
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.downloadFile("file-XjGxS3KTG0uNmNOK362iJua3");
+          request:
+            curl: |
+              curl https://api.openai.com/v1/files/file-abc123/content \
+                -H "Authorization: Bearer $OPENAI_API_KEY" > file.jsonl
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              content = openai.File.download("file-abc123")
+            node.js: |
+              import OpenAI from "openai";
 
-  /answers:
-    post:
-      operationId: createAnswer
-      deprecated: true
-      tags:
-        - OpenAI
-      summary: |
-        Answers the specified question using the provided documents and examples.
+              const openai = new OpenAI();
 
-        The endpoint first [searches](/docs/api-reference/searches) over provided documents or files to find relevant context. The relevant context is combined with the provided examples and question to create the prompt for [completion](/docs/api-reference/completions).
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateAnswerRequest"
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CreateAnswerResponse"
-      x-oaiMeta:
-        name: Create answer
-        group: answers
-        path: create
-        examples:
-          curl: |
-            curl https://api.openai.com/v1/answers \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d '{
-                "documents": ["Puppy A is happy.", "Puppy B is sad."],
-                "question": "which puppy is happy?",
-                "search_model": "ada",
-                "model": "curie",
-                "examples_context": "In 2017, U.S. life expectancy was 78.6 years.",
-                "examples": [["What is human life expectancy in the United States?","78 years."]],
-                "max_tokens": 5,
-                "stop": ["\n", "<|endoftext|>"]
-              }'
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Answer.create(
-              search_model="ada",
-              model="curie",
-              question="which puppy is happy?",
-              documents=["Puppy A is happy.", "Puppy B is sad."],
-              examples_context="In 2017, U.S. life expectancy was 78.6 years.",
-              examples=[["What is human life expectancy in the United States?","78 years."]],
-              max_tokens=5,
-              stop=["\n", "<|endoftext|>"],
-            )
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.createAnswer({
-              search_model: "ada",
-              model: "curie",
-              question: "which puppy is happy?",
-              documents: ["Puppy A is happy.", "Puppy B is sad."],
-              examples_context: "In 2017, U.S. life expectancy was 78.6 years.",
-              examples: [["What is human life expectancy in the United States?","78 years."]],
-              max_tokens: 5,
-              stop: ["\n", "<|endoftext|>"],
-            });
-        parameters: |
-          {
-            "documents": ["Puppy A is happy.", "Puppy B is sad."],
-            "question": "which puppy is happy?",
-            "search_model": "ada",
-            "model": "curie",
-            "examples_context": "In 2017, U.S. life expectancy was 78.6 years.",
-            "examples": [["What is human life expectancy in the United States?","78 years."]],
-            "max_tokens": 5,
-            "stop": ["\n", "<|endoftext|>"]
-          }
-        response: |
-          {
-            "answers": [
-              "puppy A."
-            ],
-            "completion": "cmpl-2euVa1kmKUuLpSX600M41125Mo9NI",
-            "model": "curie:2020-05-03",
-            "object": "answer",
-            "search_model": "ada",
-            "selected_documents": [
-              {
-                "document": 0,
-                "text": "Puppy A is happy. "
-              },
-              {
-                "document": 1,
-                "text": "Puppy B is sad. "
+              async function main() {
+                const file = await openai.files.retrieveContent("file-abc123");
+
+                console.log(file);
               }
-            ]
-          }
 
-  /classifications:
+              main();
+
+  /fine_tuning/jobs:
     post:
-      operationId: createClassification
-      deprecated: true
+      operationId: createFineTuningJob
       tags:
-        - OpenAI
-      summary: |
-        Classifies the specified `query` using provided examples.
-
-        The endpoint first [searches](/docs/api-reference/searches) over the labeled examples
-        to select the ones most relevant for the particular query. Then, the relevant examples
-        are combined with the query to construct a prompt to produce the final label via the
-        [completions](/docs/api-reference/completions) endpoint.
-
-        Labeled examples can be provided via an uploaded `file`, or explicitly listed in the
-        request using the `examples` parameter for quick tests and small scale use cases.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateClassificationRequest"
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CreateClassificationResponse"
-      x-oaiMeta:
-        name: Create classification
-        group: classifications
-        path: create
-        examples:
-          curl: |
-            curl https://api.openai.com/v1/classifications \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d '{
-                "examples": [
-                  ["A happy moment", "Positive"],
-                  ["I am sad.", "Negative"],
-                  ["I am feeling awesome", "Positive"]
-                ],
-                "query": "It is a raining day :(",
-                "search_model": "ada",
-                "model": "curie",
-                "labels":["Positive", "Negative", "Neutral"]
-              }'
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Classification.create(
-              search_model="ada",
-              model="curie",
-              examples=[
-                ["A happy moment", "Positive"],
-                ["I am sad.", "Negative"],
-                ["I am feeling awesome", "Positive"]
-              ],
-              query="It is a raining day :(",
-              labels=["Positive", "Negative", "Neutral"],
-            )
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.createClassification({
-              search_model: "ada",
-              model: "curie",
-              examples: [
-                ["A happy moment", "Positive"],
-                ["I am sad.", "Negative"],
-                ["I am feeling awesome", "Positive"]
-              ],
-              query:"It is a raining day :(",
-              labels: ["Positive", "Negative", "Neutral"],
-            });
-        parameters: |
-          {
-            "examples": [
-              ["A happy moment", "Positive"],
-              ["I am sad.", "Negative"],
-              ["I am feeling awesome", "Positive"]
-            ],
-            "labels": ["Positive", "Negative", "Neutral"],
-            "query": "It is a raining day :(",
-            "search_model": "ada",
-            "model": "curie"
-          }
-        response: |
-          {
-            "completion": "cmpl-2euN7lUVZ0d4RKbQqRV79IiiE6M1f",
-            "label": "Negative",
-            "model": "curie:2020-05-03",
-            "object": "classification",
-            "search_model": "ada",
-            "selected_examples": [
-              {
-                "document": 1,
-                "label": "Negative",
-                "text": "I am sad."
-              },
-              {
-                "document": 0,
-                "label": "Positive",
-                "text": "A happy moment"
-              },
-              {
-                "document": 2,
-                "label": "Positive",
-                "text": "I am feeling awesome"
-              }
-            ]
-          }
-
-  /fine-tunes:
-    post:
-      operationId: createFineTune
-      tags:
-        - OpenAI
+        - Fine-tuning
       summary: |
         Creates a job that fine-tunes a specified model from a given dataset.
 
         Response includes details of the enqueued job including job status and the name of the fine-tuned models once complete.
 
-        [Learn more about Fine-tuning](/docs/guides/fine-tuning)
+        [Learn more about fine-tuning](/docs/guides/fine-tuning)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateFineTuningJobRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FineTuningJob"
+      x-oaiMeta:
+        name: Create fine-tuning job
+        returns: A [fine-tuning.job](/docs/api-reference/fine-tuning/object) object.
+        examples:
+          - title: No hyperparameters
+            request:
+              curl: |
+                curl https://api.openai.com/v1/fine_tuning/jobs \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "training_file": "file-abc123",
+                    "model": "gpt-3.5-turbo"
+                  }'
+              python: |
+                import os
+                import openai
+                openai.api_key = os.getenv("OPENAI_API_KEY")
+                openai.FineTuningJob.create(training_file="file-abc123", model="gpt-3.5-turbo")
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const fineTune = await openai.fineTuning.jobs.create({
+                    training_file: "file-abc123"
+                  });
+
+                  console.log(fineTune);
+                }
+
+                main();
+            response: |
+              {
+                "object": "fine_tuning.job",
+                "id": "ftjob-abc123",
+                "model": "gpt-3.5-turbo-0613",
+                "created_at": 1614807352,
+                "fine_tuned_model": null,
+                "organization_id": "org-123",
+                "result_files": [],
+                "status": "queued",
+                "validation_file": null,
+                "training_file": "file-abc123",
+              }
+          - title: Hyperparameters
+            request:
+              curl: |
+                curl https://api.openai.com/v1/fine_tuning/jobs \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "training_file": "file-abc123",
+                    "model": "gpt-3.5-turbo",
+                    "hyperparameters": {
+                      "n_epochs": 2
+                    }
+                  }'
+              python: |
+                import os
+                import openai
+                openai.api_key = os.getenv("OPENAI_API_KEY")
+                openai.FineTuningJob.create(training_file="file-abc123", model="gpt-3.5-turbo", hyperparameters={"n_epochs":2})
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const fineTune = await openai.fineTuning.jobs.create({
+                    training_file: "file-abc123",
+                    model: "gpt-3.5-turbo",
+                    hyperparameters: { n_epochs: 2 }
+                  });
+
+                  console.log(fineTune);
+                }
+
+                main();
+            response: |
+              {
+                "object": "fine_tuning.job",
+                "id": "ftjob-abc123",
+                "model": "gpt-3.5-turbo-0613",
+                "created_at": 1614807352,
+                "fine_tuned_model": null,
+                "organization_id": "org-123",
+                "result_files": [],
+                "status": "queued",
+                "validation_file": null,
+                "training_file": "file-abc123",
+                "hyperparameters":{"n_epochs":2},
+              }
+          - title: Validation file
+            request:
+              curl: |
+                curl https://api.openai.com/v1/fine_tuning/jobs \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "training_file": "file-abc123",
+                    "validation_file": "file-abc123",
+                    "model": "gpt-3.5-turbo"
+                  }'
+              python: |
+                import os
+                import openai
+                openai.api_key = os.getenv("OPENAI_API_KEY")
+                openai.FineTuningJob.create(training_file="file-abc123", validation_file="file-abc123", model="gpt-3.5-turbo")
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const fineTune = await openai.fineTuning.jobs.create({
+                    training_file: "file-abc123",
+                    validation_file: "file-abc123"
+                  });
+
+                  console.log(fineTune);
+                }
+
+                main();
+            response: |
+              {
+                "object": "fine_tuning.job",
+                "id": "ftjob-abc123",
+                "model": "gpt-3.5-turbo-0613",
+                "created_at": 1614807352,
+                "fine_tuned_model": null,
+                "organization_id": "org-123",
+                "result_files": [],
+                "status": "queued",
+                "validation_file": "file-abc123",
+                "training_file": "file-abc123",
+              }
+    get:
+      operationId: listPaginatedFineTuningJobs
+      tags:
+        - Fine-tuning
+      summary: |
+        List your organization's fine-tuning jobs
+      parameters:
+        - name: after
+          in: query
+          description: Identifier for the last job from the previous pagination request.
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Number of fine-tuning jobs to retrieve.
+          required: false
+          schema:
+            type: integer
+            default: 20
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListPaginatedFineTuningJobsResponse"
+      x-oaiMeta:
+        name: List fine-tuning jobs
+        returns: A list of paginated [fine-tuning job](/docs/api-reference/fine-tuning/object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/fine_tuning/jobs?limit=2 \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.FineTuningJob.list()
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const list = await openai.fineTuning.jobs.list();
+
+                for await (const fineTune of list) {
+                  console.log(fineTune);
+                }
+              }
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "object": "fine_tuning.job.event",
+                  "id": "ft-event-TjX0lMfOniCZX64t9PUQT5hn",
+                  "created_at": 1689813489,
+                  "level": "warn",
+                  "message": "Fine tuning process stopping due to job cancellation",
+                  "data": null,
+                  "type": "message"
+                },
+                { ... },
+                { ... }
+              ], "has_more": true
+            }
+  /fine_tuning/jobs/{fine_tuning_job_id}:
+    get:
+      operationId: retrieveFineTuningJob
+      tags:
+        - Fine-tuning
+      summary: |
+        Get info about a fine-tuning job.
+
+        [Learn more about fine-tuning](/docs/guides/fine-tuning)
+      parameters:
+        - in: path
+          name: fine_tuning_job_id
+          required: true
+          schema:
+            type: string
+            example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+          description: |
+            The ID of the fine-tuning job.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FineTuningJob"
+      x-oaiMeta:
+        name: Retrieve fine-tuning job
+        returns: The [fine-tuning](/docs/api-reference/fine-tunes/object) object with the given ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/fine_tuning/jobs/ft-AF1WoRqd3aJAHsqc9NY7iL8F \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.FineTuningJob.retrieve("ftjob-abc123")
+            node.js: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const fineTune = await openai.fineTuning.jobs.retrieve("ftjob-abc123");
+                
+                console.log(fineTune);
+              }
+
+              main();
+          response: &fine_tuning_example |
+            {
+              "object": "fine_tuning.job",
+              "id": "ftjob-abc123",
+              "model": "davinci-002",
+              "created_at": 1692661014,
+              "finished_at": 1692661190,
+              "fine_tuned_model": "ft:davinci-002:my-org:custom_suffix:7q8mpxmy",
+              "organization_id": "org-123",
+              "result_files": [
+                  "file-abc123"
+              ],
+              "status": "succeeded",
+              "validation_file": null,
+              "training_file": "file-abc123",
+              "hyperparameters": {
+                  "n_epochs": 4,
+              },
+              "trained_tokens": 5768
+            }
+  /fine_tuning/jobs/{fine_tuning_job_id}/events:
+    get:
+      operationId: listFineTuningEvents
+      tags:
+        - Fine-tuning
+      summary: |
+        Get status updates for a fine-tuning job.
+      parameters:
+        - in: path
+          name: fine_tuning_job_id
+          required: true
+          schema:
+            type: string
+            example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+          description: |
+            The ID of the fine-tuning job to get events for.
+        - name: after
+          in: query
+          description: Identifier for the last event from the previous pagination request.
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Number of events to retrieve.
+          required: false
+          schema:
+            type: integer
+            default: 20
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListFineTuningJobEventsResponse"
+      x-oaiMeta:
+        name: List fine-tuning events
+        returns: A list of fine-tuning event objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/events \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.FineTuningJob.list_events(id="ftjob-abc123", limit=2)
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const list = await openai.fineTuning.list_events(id="ftjob-abc123", limit=2);
+
+                for await (const fineTune of list) {
+                  console.log(fineTune);
+                }
+              }
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "object": "fine_tuning.job.event",
+                  "id": "ft-event-ddTJfwuMVpfLXseO0Am0Gqjm",
+                  "created_at": 1692407401,
+                  "level": "info",
+                  "message": "Fine tuning job successfully completed",
+                  "data": null,
+                  "type": "message"
+                },
+                {
+                  "object": "fine_tuning.job.event",
+                  "id": "ft-event-tyiGuB72evQncpH87xe505Sv",
+                  "created_at": 1692407400,
+                  "level": "info",
+                  "message": "New fine-tuned model created: ft:gpt-3.5-turbo:openai::7p4lURel",
+                  "data": null,
+                  "type": "message"
+                }
+              ],
+              "has_more": true
+            }
+
+  /fine_tuning/jobs/{fine_tuning_job_id}/cancel:
+    post:
+      operationId: cancelFineTuningJob
+      tags:
+        - Fine-tuning
+      summary: |
+        Immediately cancel a fine-tune job.
+      parameters:
+        - in: path
+          name: fine_tuning_job_id
+          required: true
+          schema:
+            type: string
+            example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+          description: |
+            The ID of the fine-tuning job to cancel.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FineTuningJob"
+      x-oaiMeta:
+        name: Cancel fine-tuning
+        returns: The cancelled [fine-tuning](/docs/api-reference/fine-tuning/object) object.
+        examples:
+          request:
+            curl: |
+              curl -X POST https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/cancel \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.FineTuningJob.cancel("ftjob-abc123")
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const fineTune = await openai.fineTuning.jobs.cancel("ftjob-abc123");
+
+                console.log(fineTune);
+              }
+              main();
+          response: |
+            {
+              "object": "fine_tuning.job",
+              "id": "ftjob-abc123",
+              "model": "gpt-3.5-turbo-0613",
+              "created_at": 1689376978,
+              "fine_tuned_model": null,
+              "organization_id": "org-123",
+              "result_files": [],
+              "hyperparameters": {
+                "n_epochs":  "auto"
+              },
+              "status": "cancelled",
+              "validation_file": "file-abc123",
+              "training_file": "file-abc123"
+            }
+
+  /fine-tunes:
+    post:
+      operationId: createFineTune
+      deprecated: true
+      tags:
+        - Fine-tunes
+      summary: |
+        Creates a job that fine-tunes a specified model from a given dataset.
+
+        Response includes details of the enqueued job including job status and the name of the fine-tuned models once complete.
+
+        [Learn more about fine-tuning](/docs/guides/legacy-fine-tuning)
       requestBody:
         required: true
         content:
@@ -1362,71 +1705,77 @@ paths:
                 $ref: "#/components/schemas/FineTune"
       x-oaiMeta:
         name: Create fine-tune
-        group: fine-tunes
-        path: create
+        returns: A [fine-tune](/docs/api-reference/fine-tunes/object) object.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/fine-tunes \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -d '{
-                "training_file": "file-XGinujblHPwGLSztz8cPS8XY"
-              }'
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.FineTune.create(training_file="file-XGinujblHPwGLSztz8cPS8XY")
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.createFineTune({
-              training_file: "file-XGinujblHPwGLSztz8cPS8XY",
-            });
-        response: |
-          {
-            "id": "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
-            "object": "fine-tune",
-            "model": "curie",
-            "created_at": 1614807352,
-            "events": [
-              {
-                "object": "fine-tune-event",
-                "created_at": 1614807352,
-                "level": "info",
-                "message": "Job enqueued. Waiting for jobs ahead to complete. Queue number: 0."
+          request:
+            curl: |
+              curl https://api.openai.com/v1/fine-tunes \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -d '{
+                  "training_file": "file-abc123"
+                }'
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.FineTune.create(training_file="file-abc123")
+            node.js: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const fineTune = await openai.fineTunes.create({
+                  training_file: "file-abc123"
+                });
+
+                console.log(fineTune);
               }
-            ],
-            "fine_tuned_model": null,
-            "hyperparams": {
-              "batch_size": 4,
-              "learning_rate_multiplier": 0.1,
-              "n_epochs": 4,
-              "prompt_loss_weight": 0.1,
-            },
-            "organization_id": "org-...",
-            "result_files": [],
-            "status": "pending",
-            "validation_files": [],
-            "training_files": [
-              {
-                "id": "file-XGinujblHPwGLSztz8cPS8XY",
-                "object": "file",
-                "bytes": 1547276,
-                "created_at": 1610062281,
-                "filename": "my-data-train.jsonl",
-                "purpose": "fine-tune-train"
-              }
-            ],
-            "updated_at": 1614807352,
-          }
+
+              main();
+          response: |
+            {
+              "id": "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+              "object": "fine-tune",
+              "model": "curie",
+              "created_at": 1614807352,
+              "events": [
+                {
+                  "object": "fine-tune-event",
+                  "created_at": 1614807352,
+                  "level": "info",
+                  "message": "Job enqueued. Waiting for jobs ahead to complete. Queue number: 0."
+                }
+              ],
+              "fine_tuned_model": null,
+              "hyperparams": {
+                "batch_size": 4,
+                "learning_rate_multiplier": 0.1,
+                "n_epochs": 4,
+                "prompt_loss_weight": 0.1,
+              },
+              "organization_id": "org-123",
+              "result_files": [],
+              "status": "pending",
+              "validation_files": [],
+              "training_files": [
+                {
+                  "id": "file-abc123",
+                  "object": "file",
+                  "bytes": 1547276,
+                  "created_at": 1610062281,
+                  "filename": "my-data-train.jsonl",
+                  "purpose": "fine-tune-train"
+                }
+              ],
+              "updated_at": 1614807352,
+            }
     get:
       operationId: listFineTunes
+      deprecated: true
       tags:
-        - OpenAI
+        - Fine-tunes
       summary: |
         List your organization's fine-tuning jobs
       responses:
@@ -1438,56 +1787,64 @@ paths:
                 $ref: "#/components/schemas/ListFineTunesResponse"
       x-oaiMeta:
         name: List fine-tunes
-        group: fine-tunes
-        path: list
+        returns: A list of [fine-tune](/docs/api-reference/fine-tunes/object) objects.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/fine-tunes \
-              -H "Authorization: Bearer $OPENAI_API_KEY"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.FineTune.list()
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.listFineTunes();
-        response: |
-          {
-            "object": "list",
-            "data": [
-              {
-                "id": "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
-                "object": "fine-tune",
-                "model": "curie",
-                "created_at": 1614807352,
-                "fine_tuned_model": null,
-                "hyperparams": { ... },
-                "organization_id": "org-...",
-                "result_files": [],
-                "status": "pending",
-                "validation_files": [],
-                "training_files": [ { ... } ],
-                "updated_at": 1614807352,
-              },
-              { ... },
-              { ... }
-            ]
-          }
+          request:
+            curl: |
+              curl https://api.openai.com/v1/fine-tunes \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.FineTune.list()
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const list = await openai.fineTunes.list();
+
+                for await (const fineTune of list) {
+                  console.log(fineTune);
+                }
+              }
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+                  "object": "fine-tune",
+                  "model": "curie",
+                  "created_at": 1614807352,
+                  "fine_tuned_model": null,
+                  "hyperparams": { ... },
+                  "organization_id": "org-123",
+                  "result_files": [],
+                  "status": "pending",
+                  "validation_files": [],
+                  "training_files": [ { ... } ],
+                  "updated_at": 1614807352,
+                },
+                { ... },
+                { ... }
+              ]
+            }
 
   /fine-tunes/{fine_tune_id}:
     get:
       operationId: retrieveFineTune
+      deprecated: true
       tags:
-        - OpenAI
+        - Fine-tunes
       summary: |
         Gets info about the fine-tune job.
 
-        [Learn more about Fine-tuning](/docs/guides/fine-tuning)
+        [Learn more about fine-tuning](/docs/guides/legacy-fine-tuning)
       parameters:
         - in: path
           name: fine_tune_id
@@ -1506,100 +1863,106 @@ paths:
                 $ref: "#/components/schemas/FineTune"
       x-oaiMeta:
         name: Retrieve fine-tune
-        group: fine-tunes
-        path: retrieve
+        returns: The [fine-tune](/docs/api-reference/fine-tunes/object) object with the given ID.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F \
-              -H "Authorization: Bearer $OPENAI_API_KEY"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.FineTune.retrieve(id="ft-AF1WoRqd3aJAHsqc9NY7iL8F")
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.retrieveFineTune("ft-AF1WoRqd3aJAHsqc9NY7iL8F");
-        response: |
-          {
-            "id": "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
-            "object": "fine-tune",
-            "model": "curie",
-            "created_at": 1614807352,
-            "events": [
-              {
-                "object": "fine-tune-event",
-                "created_at": 1614807352,
-                "level": "info",
-                "message": "Job enqueued. Waiting for jobs ahead to complete. Queue number: 0."
-              },
-              {
-                "object": "fine-tune-event",
-                "created_at": 1614807356,
-                "level": "info",
-                "message": "Job started."
-              },
-              {
-                "object": "fine-tune-event",
-                "created_at": 1614807861,
-                "level": "info",
-                "message": "Uploaded snapshot: curie:ft-acmeco-2021-03-03-21-44-20."
-              },
-              {
-                "object": "fine-tune-event",
-                "created_at": 1614807864,
-                "level": "info",
-                "message": "Uploaded result files: file-QQm6ZpqdNwAaVC3aSz5sWwLT."
-              },
-              {
-                "object": "fine-tune-event",
-                "created_at": 1614807864,
-                "level": "info",
-                "message": "Job succeeded."
+          request:
+            curl: |
+              curl https://api.openai.com/v1/fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.FineTune.retrieve(id="ft-AF1WoRqd3aJAHsqc9NY7iL8F")
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const fineTune = await openai.fineTunes.retrieve("ft-AF1WoRqd3aJAHsqc9NY7iL8F");
+
+                console.log(fineTune);
               }
-            ],
-            "fine_tuned_model": "curie:ft-acmeco-2021-03-03-21-44-20",
-            "hyperparams": {
-              "batch_size": 4,
-              "learning_rate_multiplier": 0.1,
-              "n_epochs": 4,
-              "prompt_loss_weight": 0.1,
-            },
-            "organization_id": "org-...",
-            "result_files": [
-              {
-                "id": "file-QQm6ZpqdNwAaVC3aSz5sWwLT",
-                "object": "file",
-                "bytes": 81509,
-                "created_at": 1614807863,
-                "filename": "compiled_results.csv",
-                "purpose": "fine-tune-results"
-              }
-            ],
-            "status": "succeeded",
-            "validation_files": [],
-            "training_files": [
-              {
-                "id": "file-XGinujblHPwGLSztz8cPS8XY",
-                "object": "file",
-                "bytes": 1547276,
-                "created_at": 1610062281,
-                "filename": "my-data-train.jsonl",
-                "purpose": "fine-tune-train"
-              }
-            ],
-            "updated_at": 1614807865,
-          }
+
+              main();
+          response: &fine_tune_example |
+            {
+              "id": "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+              "object": "fine-tune",
+              "model": "curie",
+              "created_at": 1614807352,
+              "events": [
+                {
+                  "object": "fine-tune-event",
+                  "created_at": 1614807352,
+                  "level": "info",
+                  "message": "Job enqueued. Waiting for jobs ahead to complete. Queue number: 0."
+                },
+                {
+                  "object": "fine-tune-event",
+                  "created_at": 1614807356,
+                  "level": "info",
+                  "message": "Job started."
+                },
+                {
+                  "object": "fine-tune-event",
+                  "created_at": 1614807861,
+                  "level": "info",
+                  "message": "Uploaded snapshot: curie:ft-acmeco-2021-03-03-21-44-20."
+                },
+                {
+                  "object": "fine-tune-event",
+                  "created_at": 1614807864,
+                  "level": "info",
+                  "message": "Uploaded result files: file-abc123."
+                },
+                {
+                  "object": "fine-tune-event",
+                  "created_at": 1614807864,
+                  "level": "info",
+                  "message": "Job succeeded."
+                }
+              ],
+              "fine_tuned_model": "curie:ft-acmeco-2021-03-03-21-44-20",
+              "hyperparams": {
+                "batch_size": 4,
+                "learning_rate_multiplier": 0.1,
+                "n_epochs": 4,
+                "prompt_loss_weight": 0.1,
+              },
+              "organization_id": "org-123",
+              "result_files": [
+                {
+                  "id": "file-abc123",
+                  "object": "file",
+                  "bytes": 81509,
+                  "created_at": 1614807863,
+                  "filename": "compiled_results.csv",
+                  "purpose": "fine-tune-results"
+                }
+              ],
+              "status": "succeeded",
+              "validation_files": [],
+              "training_files": [
+                {
+                  "id": "file-abc123",
+                  "object": "file",
+                  "bytes": 1547276,
+                  "created_at": 1610062281,
+                  "filename": "my-data-train.jsonl",
+                  "purpose": "fine-tune-train"
+                }
+              ],
+              "updated_at": 1614807865,
+            }
 
   /fine-tunes/{fine_tune_id}/cancel:
     post:
       operationId: cancelFineTune
+      deprecated: true
       tags:
-        - OpenAI
+        - Fine-tunes
       summary: |
         Immediately cancel a fine-tune job.
       parameters:
@@ -1620,55 +1983,60 @@ paths:
                 $ref: "#/components/schemas/FineTune"
       x-oaiMeta:
         name: Cancel fine-tune
-        group: fine-tunes
-        path: cancel
+        returns: The cancelled [fine-tune](/docs/api-reference/fine-tunes/object) object.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F/cancel \
-              -H "Authorization: Bearer $OPENAI_API_KEY"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.FineTune.cancel(id="ft-AF1WoRqd3aJAHsqc9NY7iL8F")
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.cancelFineTune("ft-AF1WoRqd3aJAHsqc9NY7iL8F");
-        response: |
-          {
-            "id": "ft-xhrpBbvVUzYGo8oUO1FY4nI7",
-            "object": "fine-tune",
-            "model": "curie",
-            "created_at": 1614807770,
-            "events": [ { ... } ],
-            "fine_tuned_model": null,
-            "hyperparams": { ... },
-            "organization_id": "org-...",
-            "result_files": [],
-            "status": "cancelled",
-            "validation_files": [],
-            "training_files": [
-              {
-                "id": "file-XGinujblHPwGLSztz8cPS8XY",
-                "object": "file",
-                "bytes": 1547276,
-                "created_at": 1610062281,
-                "filename": "my-data-train.jsonl",
-                "purpose": "fine-tune-train"
+          request:
+            curl: |
+              curl https://api.openai.com/v1/fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F/cancel \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.FineTune.cancel(id="ft-AF1WoRqd3aJAHsqc9NY7iL8F")
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const fineTune = await openai.fineTunes.cancel("ft-AF1WoRqd3aJAHsqc9NY7iL8F");
+
+                console.log(fineTune);
               }
-            ],
-            "updated_at": 1614807789,
-          }
+              main();
+          response: |
+            {
+              "id": "ft-xhrpBbvVUzYGo8oUO1FY4nI7",
+              "object": "fine-tune",
+              "model": "curie",
+              "created_at": 1614807770,
+              "events": [ { ... } ],
+              "fine_tuned_model": null,
+              "hyperparams": { ... },
+              "organization_id": "org-123",
+              "result_files": [],
+              "status": "cancelled",
+              "validation_files": [],
+              "training_files": [
+                {
+                  "id": "file-abc123",
+                  "object": "file",
+                  "bytes": 1547276,
+                  "created_at": 1610062281,
+                  "filename": "my-data-train.jsonl",
+                  "purpose": "fine-tune-train"
+                }
+              ],
+              "updated_at": 1614807789,
+            }
 
   /fine-tunes/{fine_tune_id}/events:
     get:
       operationId: listFineTuneEvents
+      deprecated: true
       tags:
-        - OpenAI
+        - Fine-tunes
       summary: |
         Get fine-grained status updates for a fine-tune job.
       parameters:
@@ -1704,66 +2072,70 @@ paths:
                 $ref: "#/components/schemas/ListFineTuneEventsResponse"
       x-oaiMeta:
         name: List fine-tune events
-        group: fine-tunes
-        path: events
+        returns: A list of fine-tune event objects.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F/events \
-              -H "Authorization: Bearer $OPENAI_API_KEY"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.FineTune.list_events(id="ft-AF1WoRqd3aJAHsqc9NY7iL8F")
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.listFineTuneEvents("ft-AF1WoRqd3aJAHsqc9NY7iL8F");
-        response: |
-          {
-            "object": "list",
-            "data": [
-              {
-                "object": "fine-tune-event",
-                "created_at": 1614807352,
-                "level": "info",
-                "message": "Job enqueued. Waiting for jobs ahead to complete. Queue number: 0."
-              },
-              {
-                "object": "fine-tune-event",
-                "created_at": 1614807356,
-                "level": "info",
-                "message": "Job started."
-              },
-              {
-                "object": "fine-tune-event",
-                "created_at": 1614807861,
-                "level": "info",
-                "message": "Uploaded snapshot: curie:ft-acmeco-2021-03-03-21-44-20."
-              },
-              {
-                "object": "fine-tune-event",
-                "created_at": 1614807864,
-                "level": "info",
-                "message": "Uploaded result files: file-QQm6ZpqdNwAaVC3aSz5sWwLT."
-              },
-              {
-                "object": "fine-tune-event",
-                "created_at": 1614807864,
-                "level": "info",
-                "message": "Job succeeded."
+          request:
+            curl: |
+              curl https://api.openai.com/v1/fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F/events \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.FineTune.list_events(id="ft-AF1WoRqd3aJAHsqc9NY7iL8F")
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const fineTune = await openai.fineTunes.listEvents("ft-AF1WoRqd3aJAHsqc9NY7iL8F");
+
+                console.log(fineTune);
               }
-            ]
-          }
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "object": "fine-tune-event",
+                  "created_at": 1614807352,
+                  "level": "info",
+                  "message": "Job enqueued. Waiting for jobs ahead to complete. Queue number: 0."
+                },
+                {
+                  "object": "fine-tune-event",
+                  "created_at": 1614807356,
+                  "level": "info",
+                  "message": "Job started."
+                },
+                {
+                  "object": "fine-tune-event",
+                  "created_at": 1614807861,
+                  "level": "info",
+                  "message": "Uploaded snapshot: curie:ft-acmeco-2021-03-03-21-44-20."
+                },
+                {
+                  "object": "fine-tune-event",
+                  "created_at": 1614807864,
+                  "level": "info",
+                  "message": "Uploaded result files: file-abc123"
+                },
+                {
+                  "object": "fine-tune-event",
+                  "created_at": 1614807864,
+                  "level": "info",
+                  "message": "Job succeeded."
+                }
+              ]
+            }
 
   /models:
     get:
       operationId: listModels
       tags:
-        - OpenAI
+        - Models
       summary: Lists the currently available models, and provides basic information about each one such as the owner and availability.
       responses:
         "200":
@@ -1774,54 +2146,61 @@ paths:
                 $ref: "#/components/schemas/ListModelsResponse"
       x-oaiMeta:
         name: List models
-        group: models
-        path: list
+        returns: A list of [model](/docs/api-reference/models/object) objects.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/models \
-              -H "Authorization: Bearer $OPENAI_API_KEY"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Model.list()
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.listModels();
-        response: |
-          {
-            "data": [
-              {
-                "id": "model-id-0",
-                "object": "model",
-                "owned_by": "organization-owner",
-                "permission": [...]
-              },
-              {
-                "id": "model-id-1",
-                "object": "model",
-                "owned_by": "organization-owner",
-                "permission": [...]
-              },
-              {
-                "id": "model-id-2",
-                "object": "model",
-                "owned_by": "openai",
-                "permission": [...]
-              },
-            ],
-            "object": "list"
-          }
+          request:
+            curl: |
+              curl https://api.openai.com/v1/models \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.Model.list()
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const list = await openai.models.list();
+
+                for await (const model of list) {
+                  console.log(model);
+                }
+              }
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "model-id-0",
+                  "object": "model",
+                  "created": 1686935002,
+                  "owned_by": "organization-owner"
+                },
+                {
+                  "id": "model-id-1",
+                  "object": "model",
+                  "created": 1686935002,
+                  "owned_by": "organization-owner",
+                },
+                {
+                  "id": "model-id-2",
+                  "object": "model",
+                  "created": 1686935002,
+                  "owned_by": "openai"
+                },
+              ],
+              "object": "list"
+            }
 
   /models/{model}:
     get:
       operationId: retrieveModel
       tags:
-        - OpenAI
+        - Models
       summary: Retrieves a model instance, providing basic information about the model such as the owner and permissioning.
       parameters:
         - in: path
@@ -1830,7 +2209,7 @@ paths:
           schema:
             type: string
             # ideally this will be an actual ID, so this will always work from browser
-            example: text-davinci-001
+            example: gpt-3.5-turbo
           description: The ID of the model to use for this request
       responses:
         "200":
@@ -1841,43 +2220,48 @@ paths:
                 $ref: "#/components/schemas/Model"
       x-oaiMeta:
         name: Retrieve model
-        group: models
-        path: retrieve
+        returns: The [model](/docs/api-reference/models/object) object matching the specified ID.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/models/VAR_model_id \
-              -H "Authorization: Bearer $OPENAI_API_KEY"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Model.retrieve("VAR_model_id")
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.retrieveModel("VAR_model_id");
-        response: |
-          {
-            "id": "VAR_model_id",
-            "object": "model",
-            "owned_by": "openai",
-            "permission": [...]
-          }
+          request:
+            curl: |
+              curl https://api.openai.com/v1/models/VAR_model_id \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.Model.retrieve("VAR_model_id")
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const model = await openai.models.retrieve("gpt-3.5-turbo");
+
+                console.log(model);
+              }
+
+              main();
+          response: &retrieve_model_response |
+            {
+              "id": "VAR_model_id",
+              "object": "model",
+              "created": 1686935002,
+              "owned_by": "openai"
+            }
     delete:
       operationId: deleteModel
       tags:
-        - OpenAI
-      summary: Delete a fine-tuned model. You must have the Owner role in your organization.
+        - Models
+      summary: Delete a fine-tuned model. You must have the Owner role in your organization to delete a model.
       parameters:
         - in: path
           name: model
           required: true
           schema:
             type: string
-            example: curie:ft-acmeco-2021-03-03-21-44-20
+            example: ft:gpt-3.5-turbo:acemeco:suffix:abc123
           description: The model to delete
       responses:
         "200":
@@ -1888,37 +2272,41 @@ paths:
                 $ref: "#/components/schemas/DeleteModelResponse"
       x-oaiMeta:
         name: Delete fine-tune model
-        group: fine-tunes
-        path: delete-model
+        returns: Deletion status.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/models/curie:ft-acmeco-2021-03-03-21-44-20 \
-              -X DELETE \
-              -H "Authorization: Bearer $OPENAI_API_KEY"
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Model.delete("curie:ft-acmeco-2021-03-03-21-44-20")
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.deleteModel('curie:ft-acmeco-2021-03-03-21-44-20');
-        response: |
-          {
-            "id": "curie:ft-acmeco-2021-03-03-21-44-20",
-            "object": "model",
-            "deleted": true
-          }
+          request:
+            curl: |
+              curl https://api.openai.com/v1/models/ft:gpt-3.5-turbo:acemeco:suffix:abc123 \
+                -X DELETE \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.Model.delete("ft:gpt-3.5-turbo:acemeco:suffix:abc123")
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const model = await openai.models.del("ft:gpt-3.5-turbo:acemeco:suffix:abc123");
+
+                console.log(model);
+              }
+              main();
+          response: |
+            {
+              "id": "ft:gpt-3.5-turbo:acemeco:suffix:abc123",
+              "object": "model",
+              "deleted": true
+            }
 
   /moderations:
     post:
       operationId: createModeration
       tags:
-        - OpenAI
+        - Moderations
       summary: Classifies if text violates OpenAI's Content Policy
       requestBody:
         required: true
@@ -1935,82 +2323,94 @@ paths:
                 $ref: "#/components/schemas/CreateModerationResponse"
       x-oaiMeta:
         name: Create moderation
-        group: moderations
-        path: create
+        returns: A [moderation](/docs/api-reference/moderations/object) object.
         examples:
-          curl: |
-            curl https://api.openai.com/v1/moderations \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer $OPENAI_API_KEY" \
-              -d '{
-                "input": "I want to kill them."
-              }'
-          python: |
-            import os
-            import openai
-            openai.api_key = os.getenv("OPENAI_API_KEY")
-            openai.Moderation.create(
-              input="I want to kill them.",
-            )
-          node.js: |
-            const { Configuration, OpenAIApi } = require("openai");
-            const configuration = new Configuration({
-              apiKey: process.env.OPENAI_API_KEY,
-            });
-            const openai = new OpenAIApi(configuration);
-            const response = await openai.createModeration({
-              input: "I want to kill them.",
-            });
-        parameters: |
-          {
-            "input": "I want to kill them."
-          }
-        response: |
-          {
-            "id": "modr-5MWoLO",
-            "model": "text-moderation-001",
-            "results": [
-              {
-                "categories": {
-                  "hate": false,
-                  "hate/threatening": true,
-                  "self-harm": false,
-                  "sexual": false,
-                  "sexual/minors": false,
-                  "violence": true,
-                  "violence/graphic": false
-                },
-                "category_scores": {
-                  "hate": 0.22714105248451233,
-                  "hate/threatening": 0.4132447838783264,
-                  "self-harm": 0.005232391878962517,
-                  "sexual": 0.01407341007143259,
-                  "sexual/minors": 0.0038522258400917053,
-                  "violence": 0.9223177433013916,
-                  "violence/graphic": 0.036865197122097015
-                },
-                "flagged": true
+          request:
+            curl: |
+              curl https://api.openai.com/v1/moderations \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -d '{
+                  "input": "I want to kill them."
+                }'
+            python: |
+              import os
+              import openai
+              openai.api_key = os.getenv("OPENAI_API_KEY")
+              openai.Moderation.create(
+                input="I want to kill them.",
+              )
+            node.js: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const moderation = await openai.moderations.create({ input: "I want to kill them." });
+
+                console.log(moderation);
               }
-            ]
-          }
+              main();
+          response: &moderation_example |
+            {
+              "id": "modr-XXXXX",
+              "model": "text-moderation-005",
+              "results": [
+                {
+                  "flagged": true,
+                  "categories": {
+                    "sexual": false,
+                    "hate": false,
+                    "harassment": false,
+                    "self-harm": false,
+                    "sexual/minors": false,
+                    "hate/threatening": false,
+                    "violence/graphic": false,
+                    "self-harm/intent": false,
+                    "self-harm/instructions": false,
+                    "harassment/threatening": true,
+                    "violence": true,
+                  },
+                  "category_scores": {
+                    "sexual": 1.2282071e-06,
+                    "hate": 0.010696256,
+                    "harassment": 0.29842457,
+                    "self-harm": 1.5236925e-08,
+                    "sexual/minors": 5.7246268e-08,
+                    "hate/threatening": 0.0060676364,
+                    "violence/graphic": 4.435014e-06,
+                    "self-harm/intent": 8.098441e-10,
+                    "self-harm/instructions": 2.8498655e-11,
+                    "harassment/threatening": 0.63055265,
+                    "violence": 0.99011886,
+                  }
+                }
+              ]
+            }
 
 components:
+
+  securitySchemes:
+    ApiKeyAuth:
+      type: http
+      scheme: 'bearer'
+
   schemas:
     Error:
       type: object
       properties:
-        type:
+        code:
           type: string
-          nullable: false
+          nullable: true
         message:
           type: string
           nullable: false
         param:
           type: string
           nullable: true
-        code:
+        type:
           type: string
-          nullable: true
+          nullable: false
       required:
         - type
         - message
@@ -2024,18 +2424,6 @@ components:
           $ref: "#/components/schemas/Error"
       required:
         - error
-    ListEnginesResponse:
-      type: object
-      properties:
-        object:
-          type: string
-        data:
-          type: array
-          items:
-            $ref: "#/components/schemas/Engine"
-      required:
-        - object
-        - data
 
     ListModelsResponse:
       type: object
@@ -2055,10 +2443,10 @@ components:
       properties:
         id:
           type: string
-        object:
-          type: string
         deleted:
           type: boolean
+        object:
+          type: string
       required:
         - id
         - object
@@ -2067,9 +2455,26 @@ components:
     CreateCompletionRequest:
       type: object
       properties:
-        model: &model_configuration
-          description: ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.
-          type: string
+        model:
+          description: &model_description |
+            ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                [
+                  "babbage-002",
+                  "davinci-002",
+                  "gpt-3.5-turbo-instruct",
+                  "text-davinci-003",
+                  "text-davinci-002",
+                  "text-davinci-001",
+                  "code-davinci-002",
+                  "text-curie-001",
+                  "text-babbage-001",
+                  "text-ada-001",
+                ]
+          x-oaiTypeLabel: string
         prompt:
           description: &completions_prompt_description |
             The prompt(s) to generate completions for, encoded as a string, array of strings, array of tokens, or array of token arrays.
@@ -2099,12 +2504,57 @@ components:
                 items:
                   type: integer
               example: "[[1212, 318, 257, 1332, 13]]"
-        suffix:
-          description: The suffix that comes after a completion of inserted text.
+        best_of:
+          type: integer
+          default: 1
+          minimum: 0
+          maximum: 20
+          nullable: true
+          description: &completions_best_of_description |
+            Generates `best_of` completions server-side and returns the "best" (the one with the highest log probability per token). Results cannot be streamed.
+            
+            When used with `n`, `best_of` controls the number of candidate completions and `n` specifies how many to return – `best_of` must be greater than `n`.
+
+            **Note:** Because this parameter generates many completions, it can quickly consume your token quota. Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.
+        echo:
+          type: boolean
+          default: false
+          nullable: true
+          description: &completions_echo_description >
+            Echo back the prompt in addition to the completion
+        frequency_penalty:
+          type: number
+          default: 0
+          minimum: -2
+          maximum: 2
+          nullable: true
+          description: &completions_frequency_penalty_description |
+            Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
+
+            [See more information about frequency and presence penalties.](/docs/guides/gpt/parameter-details)
+        logit_bias: &completions_logit_bias
+          type: object
+          x-oaiTypeLabel: map
           default: null
           nullable: true
-          type: string
-          example: "test."
+          additionalProperties:
+            type: integer
+          description: &completions_logit_bias_description |
+            Modify the likelihood of specified tokens appearing in the completion.
+
+            Accepts a json object that maps tokens (specified by their token ID in the GPT tokenizer) to an associated bias value from -100 to 100. You can use this [tokenizer tool](/tokenizer?view=bpe) (which works for both GPT-2 and GPT-3) to convert text to token IDs. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
+
+            As an example, you can pass `{"50256": -100}` to prevent the <|endoftext|> token from being generated.
+        logprobs: &completions_logprobs_configuration
+          type: integer
+          minimum: 0
+          maximum: 5
+          default: null
+          nullable: true
+          description: &completions_logprobs_description |
+            Include the log probabilities on the `logprobs` most likely tokens, as well the chosen tokens. For example, if `logprobs` is 5, the API will return a list of the 5 most likely tokens. The API will always return the `logprob` of the sampled token, so there may be up to `logprobs+1` elements in the response.
+
+            The maximum value for `logprobs` is 5.
         max_tokens:
           type: integer
           minimum: 0
@@ -2114,7 +2564,57 @@ components:
           description: &completions_max_tokens_description |
             The maximum number of [tokens](/tokenizer) to generate in the completion.
 
-            The token count of your prompt plus `max_tokens` cannot exceed the model's context length. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb) for counting tokens.
+            The token count of your prompt plus `max_tokens` cannot exceed the model's context length. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.
+        n:
+          type: integer
+          minimum: 1
+          maximum: 128
+          default: 1
+          example: 1
+          nullable: true
+          description: &completions_completions_description |
+            How many completions to generate for each prompt.
+
+            **Note:** Because this parameter generates many completions, it can quickly consume your token quota. Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.
+        presence_penalty:
+          type: number
+          default: 0
+          minimum: -2
+          maximum: 2
+          nullable: true
+          description: &completions_presence_penalty_description |
+            Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
+
+            [See more information about frequency and presence penalties.](/docs/guides/gpt/parameter-details)
+        stop:
+          description: &completions_stop_description >
+            Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence.
+          default: null
+          nullable: true
+          oneOf:
+            - type: string
+              default: <|endoftext|>
+              example: "\n"
+              nullable: true
+            - type: array
+              minItems: 1
+              maxItems: 4
+              items:
+                type: string
+                example: '["\n"]'
+        stream:
+          description: >
+            Whether to stream back partial progress. If set, tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format)
+            as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).
+          type: boolean
+          nullable: true
+          default: false
+        suffix:
+          description: The suffix that comes after a completion of inserted text.
+          default: null
+          nullable: true
+          type: string
+          example: "test."
         temperature:
           type: number
           minimum: 0
@@ -2137,99 +2637,6 @@ components:
             An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
 
             We generally recommend altering this or `temperature` but not both.
-        n:
-          type: integer
-          minimum: 1
-          maximum: 128
-          default: 1
-          example: 1
-          nullable: true
-          description: &completions_completions_description |
-            How many completions to generate for each prompt.
-
-            **Note:** Because this parameter generates many completions, it can quickly consume your token quota. Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.
-        stream:
-          description: >
-            Whether to stream back partial progress. If set, tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format)
-            as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_stream_completions.ipynb).
-          type: boolean
-          nullable: true
-          default: false
-        logprobs: &completions_logprobs_configuration
-          type: integer
-          minimum: 0
-          maximum: 5
-          default: null
-          nullable: true
-          description: &completions_logprobs_description |
-            Include the log probabilities on the `logprobs` most likely tokens, as well the chosen tokens. For example, if `logprobs` is 5, the API will return a list of the 5 most likely tokens. The API will always return the `logprob` of the sampled token, so there may be up to `logprobs+1` elements in the response.
-
-            The maximum value for `logprobs` is 5.
-        echo:
-          type: boolean
-          default: false
-          nullable: true
-          description: &completions_echo_description >
-            Echo back the prompt in addition to the completion
-        stop:
-          description: &completions_stop_description >
-            Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence.
-          default: null
-          nullable: true
-          oneOf:
-            - type: string
-              default: <|endoftext|>
-              example: "\n"
-              nullable: true
-            - type: array
-              minItems: 1
-              maxItems: 4
-              items:
-                type: string
-                example: '["\n"]'
-        presence_penalty:
-          type: number
-          default: 0
-          minimum: -2
-          maximum: 2
-          nullable: true
-          description: &completions_presence_penalty_description |
-            Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
-
-            [See more information about frequency and presence penalties.](/docs/api-reference/parameter-details)
-        frequency_penalty:
-          type: number
-          default: 0
-          minimum: -2
-          maximum: 2
-          nullable: true
-          description: &completions_frequency_penalty_description |
-            Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
-
-            [See more information about frequency and presence penalties.](/docs/api-reference/parameter-details)
-        best_of:
-          type: integer
-          default: 1
-          minimum: 0
-          maximum: 20
-          nullable: true
-          description: &completions_best_of_description |
-            Generates `best_of` completions server-side and returns the "best" (the one with the highest log probability per token). Results cannot be streamed.
-
-            When used with `n`, `best_of` controls the number of candidate completions and `n` specifies how many to return – `best_of` must be greater than `n`.
-
-            **Note:** Because this parameter generates many completions, it can quickly consume your token quota. Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.
-        logit_bias: &completions_logit_bias
-          type: object
-          x-oaiTypeLabel: map
-          default: null
-          nullable: true
-          description: &completions_logit_bias_description |
-            Modify the likelihood of specified tokens appearing in the completion.
-
-            Accepts a json object that maps tokens (specified by their token ID in the GPT tokenizer) to an associated bias value from -100 to 100. You can use this [tokenizer tool](/tokenizer?view=bpe) (which works for both GPT-2 and GPT-3) to convert text to token IDs. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
-
-            As an example, you can pass `{"50256": -100}` to prevent the <|endoftext|> token from being generated.
         user: &end_user_param_configuration
           type: string
           example: user-1234
@@ -2237,145 +2644,195 @@ components:
             A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).
       required:
         - model
+        - prompt
 
     CreateCompletionResponse:
       type: object
+      description: |
+        Represents a completion response from the API. Note: both the streamed and non-streamed response objects share the same shape (unlike the chat endpoint).
       properties:
         id:
           type: string
-        object:
-          type: string
-        created:
-          type: integer
-        model:
-          type: string
+          description: A unique identifier for the completion.
         choices:
           type: array
+          description: The list of completion choices the model generated for the input prompt.
           items:
             type: object
+            required:
+              - finish_reason
+              - index
+              - logprobs
+              - text
             properties:
-              text:
+              finish_reason:
                 type: string
+                description: &completion_finish_reason_description |
+                  The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,
+                  `length` if the maximum number of tokens specified in the request was reached,
+                  or `content_filter` if content was omitted due to a flag from our content filters.
+                enum: ["stop", "length", "content_filter"]
               index:
                 type: integer
               logprobs:
                 type: object
                 nullable: true
                 properties:
-                  tokens:
-                    type: array
-                    items:
-                      type: string
-                  token_logprobs:
-                    type: array
-                    items:
-                      type: number
-                  top_logprobs:
-                    type: array
-                    items:
-                      type: object
                   text_offset:
                     type: array
                     items:
                       type: integer
-              finish_reason:
+                  token_logprobs:
+                    type: array
+                    items:
+                      type: number
+                  tokens:
+                    type: array
+                    items:
+                      type: string
+                  top_logprobs:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties:
+                        type: integer
+              text:
                 type: string
+        created:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the completion was created.
+        model:
+          type: string
+          description: The model used for completion.
+        object:
+          type: string
+          description: The object type, which is always "text_completion"
         usage:
-          type: object
-          properties:
-            prompt_tokens:
-              type: integer
-            completion_tokens:
-              type: integer
-            total_tokens:
-              type: integer
-          required:
-            - prompt_tokens
-            - completion_tokens
-            - total_tokens
+          $ref: "#/components/schemas/CompletionUsage"
       required:
         - id
         - object
         - created
         - model
         - choices
+      x-oaiMeta:
+        name: The completion object
+        legacy: true
+        example: |
+          {
+            "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
+            "object": "text_completion",
+            "created": 1589478378,
+            "model": "gpt-3.5-turbo",
+            "choices": [
+              {
+                "text": "\n\nThis is indeed a test",
+                "index": 0,
+                "logprobs": null,
+                "finish_reason": "length"
+              }
+            ],
+            "usage": {
+              "prompt_tokens": 5,
+              "completion_tokens": 7,
+              "total_tokens": 12
+            }
+          }
+
 
     ChatCompletionRequestMessage:
       type: object
       properties:
-        role:
-          type: string
-          enum: ["system", "user", "assistant", "function"]
-          description: The role of the messages author. One of `system`, `user`, `assistant`, or `function`.
         content:
           type: string
-          description: The contents of the message. `content` is required for all messages except assistant messages with function calls.
-        name:
-          type: string
-          description: The name of the author of this message. `name` is required if role is `function`, and it should be the name of the function whose response is in the `content`. May contain a-z, A-Z, 0-9, and underscores, with a maximum length of 64 characters.
+          nullable: true
+          description: The contents of the message. `content` is required for all messages, and may be null for assistant messages with function calls.
         function_call:
           type: object
           description: The name and arguments of a function that should be called, as generated by the model.
           properties:
-            name:
-              type: string
-              description: The name of the function to call.
             arguments:
               type: string
               description: The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.
+            name:
+              type: string
+              description: The name of the function to call.
+          required:
+            - arguments
+            - name
+        name:
+          type: string
+          description: The name of the author of this message. `name` is required if role is `function`, and it should be the name of the function whose response is in the `content`. May contain a-z, A-Z, 0-9, and underscores, with a maximum length of 64 characters.
+        role:
+          type: string
+          enum: ["system", "user", "assistant", "function"]
+          description: The role of the messages author. One of `system`, `user`, `assistant`, or `function`.
       required:
+        - content
         - role
 
     ChatCompletionFunctionParameters:
       type: object
-      description: The parameters the functions accepts, described as a JSON Schema object. See the [guide](/docs/guides/gpt/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format.
-      # TODO type this as json schema
+      description: "The parameters the functions accepts, described as a JSON Schema object. See the [guide](/docs/guides/gpt/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format.\n\nTo describe a function that accepts no parameters, provide the value `{\"type\": \"object\", \"properties\": {}}`."
       additionalProperties: true
 
     ChatCompletionFunctions:
       type: object
       properties:
+        description:
+          type: string
+          description: A description of what the function does, used by the model to choose when and how to call the function.
         name:
           type: string
           description: The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.
-        description:
-          type: string
-          description: The description of what the function does.
         parameters:
           $ref: "#/components/schemas/ChatCompletionFunctionParameters"
+      required:
+        - name
+        - parameters
+
+    ChatCompletionFunctionCallOption:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the function to call.
       required:
         - name
 
     ChatCompletionResponseMessage:
       type: object
+      description: A chat completion message generated by the model.
       properties:
-        role:
-          type: string
-          enum: ["system", "user", "assistant", "function"]
-          description: The role of the author of this message.
         content:
           type: string
           description: The contents of the message.
+          nullable: true
         function_call:
           type: object
           description: The name and arguments of a function that should be called, as generated by the model.
           properties:
-            name:
-              type: string
-              description: The name of the function to call.
             arguments:
               type: string
               description: The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.
-      required:
-        - role
-
-    ChatCompletionStreamResponseDelta:
-      type: object
-      properties:
+            name:
+              type: string
+              description: The name of the function to call.
+          required:
+            - name
+            - arguments
         role:
           type: string
           enum: ["system", "user", "assistant", "function"]
           description: The role of the author of this message.
+      required:
+        - role
+        - content
+
+    ChatCompletionStreamResponseDelta:
+      type: object
+      description: A chat completion delta generated by streamed model responses.
+      properties:
         content:
           type: string
           description: The contents of the chunk message.
@@ -2384,43 +2841,121 @@ components:
           type: object
           description: The name and arguments of a function that should be called, as generated by the model.
           properties:
-            name:
-              type: string
-              description: The name of the function to call.
             arguments:
               type: string
               description: The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.
+            name:
+              type: string
+              description: The name of the function to call.
+        role:
+          type: string
+          enum: ["system", "user", "assistant", "function"]
+          description: The role of the author of this message.
 
     CreateChatCompletionRequest:
       type: object
       properties:
-        model:
-          description: ID of the model to use. See the [model endpoint compatibility](/docs/models/model-endpoint-compatibility) table for details on which models work with the Chat API.
-          type: string
         messages:
-          description: A list of messages comprising the conversation so far. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_format_inputs_to_ChatGPT_models.ipynb).
+          description: A list of messages comprising the conversation so far. [Example Python code](https://cookbook.openai.com/examples/how_to_format_inputs_to_chatgpt_models).
           type: array
           minItems: 1
           items:
             $ref: "#/components/schemas/ChatCompletionRequestMessage"
+        model:
+          description: ID of the model to use. See the [model endpoint compatibility](/docs/models/model-endpoint-compatibility) table for details on which models work with the Chat API.
+          example: "gpt-3.5-turbo"
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                [
+                  "gpt-4",
+                  "gpt-4-0314",
+                  "gpt-4-0613",
+                  "gpt-4-32k",
+                  "gpt-4-32k-0314",
+                  "gpt-4-32k-0613",
+                  "gpt-3.5-turbo",
+                  "gpt-3.5-turbo-16k",
+                  "gpt-3.5-turbo-0301",
+                  "gpt-3.5-turbo-0613",
+                  "gpt-3.5-turbo-16k-0613",
+                ]
+          x-oaiTypeLabel: string
+        frequency_penalty:
+          type: number
+          default: 0
+          minimum: -2
+          maximum: 2
+          nullable: true
+          description: *completions_frequency_penalty_description
+        function_call:
+          description: > 
+            Controls how the model calls functions. "none" means the model will not call a function and instead generates a message. "auto" means the model can pick between generating a message or calling a function.  Specifying a particular function via `{"name": "my_function"}` forces the model to call that function. "none" is the default when no functions are present. "auto" is the default if functions are present.
+          oneOf:
+            - type: string
+              enum: [none, auto]
+            - $ref: "#/components/schemas/ChatCompletionFunctionCallOption"
         functions:
           description: A list of functions the model may generate JSON inputs for.
           type: array
           minItems: 1
+          maxItems: 128
           items:
             $ref: "#/components/schemas/ChatCompletionFunctions"
-        function_call:
-          description: Controls how the model responds to function calls. "none" means the model does not call a function, and responds to the end-user. "auto" means the model can pick between an end-user or calling a function.  Specifying a particular function via `{"name":\ "my_function"}` forces the model to call that function. "none" is the default when no functions are present. "auto" is the default if functions are present.
+        logit_bias:
+          type: object
+          x-oaiTypeLabel: map
+          default: null
+          nullable: true
+          additionalProperties:
+            type: integer
+          description: |
+            Modify the likelihood of specified tokens appearing in the completion.
+
+            Accepts a json object that maps tokens (specified by their token ID in the tokenizer) to an associated bias value from -100 to 100. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
+        max_tokens:
+          description: |
+            The maximum number of [tokens](/tokenizer) to generate in the chat completion.
+
+            The total length of input tokens and generated tokens is limited by the model's context length. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.
+          default: inf
+          type: integer
+          nullable: true
+        n:
+          type: integer
+          minimum: 1
+          maximum: 128
+          default: 1
+          example: 1
+          nullable: true
+          description: How many chat completion choices to generate for each input message.
+        presence_penalty:
+          type: number
+          default: 0
+          minimum: -2
+          maximum: 2
+          nullable: true
+          description: *completions_presence_penalty_description
+        stop:
+          description: |
+            Up to 4 sequences where the API will stop generating further tokens.
+          default: null
           oneOf:
             - type: string
-              enum: [none, auto]
-            - type: object
-              properties:
-                name:
-                  type: string
-                  description: The name of the function to call.
-              required:
-                - name
+              nullable: true
+            - type: array
+              minItems: 1
+              maxItems: 4
+              items:
+                type: string
+        stream:
+          description: >
+            If set, partial message deltas will be sent, like in ChatGPT. Tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format)
+            as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).
+          type: boolean
+          nullable: true
+          default: false
         temperature:
           type: number
           minimum: 0
@@ -2437,63 +2972,6 @@ components:
           example: 1
           nullable: true
           description: *completions_top_p_description
-        n:
-          type: integer
-          minimum: 1
-          maximum: 128
-          default: 1
-          example: 1
-          nullable: true
-          description: How many chat completion choices to generate for each input message.
-        stream:
-          description: >
-            If set, partial message deltas will be sent, like in ChatGPT. Tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format)
-            as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_stream_completions.ipynb).
-          type: boolean
-          nullable: true
-          default: false
-        stop:
-          description: |
-            Up to 4 sequences where the API will stop generating further tokens.
-          default: null
-          oneOf:
-            - type: string
-              nullable: true
-            - type: array
-              minItems: 1
-              maxItems: 4
-              items:
-                type: string
-        max_tokens:
-          description: |
-            The maximum number of [tokens](/tokenizer) to generate in the chat completion.
-
-            The total length of input tokens and generated tokens is limited by the model's context length. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb) for counting tokens.
-          default: inf
-          type: integer
-        presence_penalty:
-          type: number
-          default: 0
-          minimum: -2
-          maximum: 2
-          nullable: true
-          description: *completions_presence_penalty_description
-        frequency_penalty:
-          type: number
-          default: 0
-          minimum: -2
-          maximum: 2
-          nullable: true
-          description: *completions_frequency_penalty_description
-        logit_bias:
-          type: object
-          x-oaiTypeLabel: map
-          default: null
-          nullable: true
-          description: |
-            Modify the likelihood of specified tokens appearing in the completion.
-
-            Accepts a json object that maps tokens (specified by their token ID in the tokenizer) to an associated bias value from -100 to 100. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
         user: *end_user_param_configuration
       required:
         - model
@@ -2501,92 +2979,189 @@ components:
 
     CreateChatCompletionResponse:
       type: object
+      description: Represents a chat completion response returned by model, based on the provided input.
       properties:
         id:
           type: string
-        object:
-          type: string
-        created:
-          type: integer
-        model:
-          type: string
+          description: A unique identifier for the chat completion.
         choices:
           type: array
+          description: A list of chat completion choices. Can be more than one if `n` is greater than 1.
           items:
             type: object
+            required:
+              - finish_reason
+              - index
+              - message
             properties:
-              index:
-                type: integer
-              message:
-                $ref: "#/components/schemas/ChatCompletionResponseMessage"
               finish_reason:
                 type: string
+                description: &chat_completion_finish_reason_description |
+                  The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,
+                  `length` if the maximum number of tokens specified in the request was reached,
+                  `content_filter` if content was omitted due to a flag from our content filters,
+                  or `function_call` if the model called a function.
+                enum: ["stop", "length", "function_call", "content_filter"]
+              index:
+                type: integer
+                description: The index of the choice in the list of choices.
+              message:
+                $ref: "#/components/schemas/ChatCompletionResponseMessage"
+        created:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the chat completion was created.
+        model:
+          type: string
+          description: The model used for the chat completion.
+        object:
+          type: string
+          description: The object type, which is always `chat.completion`.
         usage:
-          type: object
-          properties:
-            prompt_tokens:
-              type: integer
-            completion_tokens:
-              type: integer
-            total_tokens:
-              type: integer
-          required:
-            - prompt_tokens
-            - completion_tokens
-            - total_tokens
+          $ref: "#/components/schemas/CompletionUsage"
       required:
-        - id
-        - object
-        - created
-        - model
         - choices
+        - created
+        - id
+        - model
+        - object
+      x-oaiMeta:
+        name: The chat completion object
+        group: chat
+        example: *chat_completion_example
+
+    CreateChatCompletionFunctionResponse:
+      type: object
+      description: Represents a chat completion response returned by model, based on the provided input.
+      properties:
+        id:
+          type: string
+          description: A unique identifier for the chat completion.
+        choices:
+          type: array
+          description: A list of chat completion choices. Can be more than one if `n` is greater than 1.
+          items:
+            type: object
+            required:
+              - finish_reason
+              - index
+              - message
+            properties:
+              finish_reason:
+                type: string
+                description: &chat_completion_function_finish_reason_description |
+                  The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence, `length` if the maximum number of tokens specified in the request was reached, `content_filter` if content was omitted due to a flag from our content filters, or `function_call` if the model called a function.
+                enum: ["stop", "length", "function_call", "content_filter"]
+              index:
+                type: integer
+                description: The index of the choice in the list of choices.
+              message:
+                $ref: "#/components/schemas/ChatCompletionResponseMessage"
+        created:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the chat completion was created.
+        model:
+          type: string
+          description: The model used for the chat completion.
+        object:
+          type: string
+          description: The object type, which is always `chat.completion`.
+        usage:
+          $ref: "#/components/schemas/CompletionUsage"
+      required:
+        - choices
+        - created
+        - id
+        - model
+        - object
+      x-oaiMeta:
+        name: The chat completion object
+        group: chat
+        example: *chat_completion_function_example
+
+    ListPaginatedFineTuningJobsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/FineTuningJob"
+        has_more:
+          type: boolean
+        object:
+          type: string
+      required:
+        - object
+        - data
+        - has_more
 
     CreateChatCompletionStreamResponse:
       type: object
+      description: Represents a streamed chunk of a chat completion response returned by model, based on the provided input.
       properties:
         id:
           type: string
-        object:
-          type: string
-        created:
-          type: integer
-        model:
-          type: string
+          description: A unique identifier for the chat completion. Each chunk has the same ID.
         choices:
           type: array
+          description: A list of chat completion choices. Can be more than one if `n` is greater than 1.
           items:
             type: object
+            required:
+              - delta
+              - finish_reason
+              - index
             properties:
-              index:
-                type: integer
               delta:
-                $ref: '#/components/schemas/ChatCompletionStreamResponseDelta'
+                $ref: "#/components/schemas/ChatCompletionStreamResponseDelta"
               finish_reason:
                 type: string
-                enum: ["stop", "length", "function_call"]
-      required: 
-        - id
-        - object
-        - created
-        - model
+                description: *chat_completion_finish_reason_description
+                enum: ["stop", "length", "function_call", "content_filter"]
+                nullable: true
+              index:
+                type: integer
+                description: The index of the choice in the list of choices.
+        created:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the chat completion was created. Each chunk has the same timestamp.
+        model:
+          type: string
+          description: The model to generate the completion.
+        object:
+          type: string
+          description: The object type, which is always `chat.completion.chunk`.
+      required:
         - choices
+        - created
+        - id
+        - model
+        - object
+      x-oaiMeta:
+        name: The chat completion chunk object
+        group: chat
+        example: *chat_completion_chunk_example
 
     CreateEditRequest:
       type: object
       properties:
+        instruction:
+          description: The instruction that tells the model how to edit the prompt.
+          type: string
+          example: "Fix the spelling mistakes."
         model:
           description: ID of the model to use. You can use the `text-davinci-edit-001` or `code-davinci-edit-001` model with this endpoint.
-          type: string
+          example: "text-davinci-edit-001"
+          anyOf:
+            - type: string
+            - type: string
+              enum: ["text-davinci-edit-001", "code-davinci-edit-001"]
+          x-oaiTypeLabel: string
         input:
           description: The input text to use as a starting point for the edit.
           type: string
           default: ""
           nullable: true
           example: "What day of the wek is it?"
-        instruction:
-          description: The instruction that tells the model how to edit the prompt.
-          type: string
-          example: "Fix the spelling mistakes."
         n:
           type: integer
           minimum: 1
@@ -2617,60 +3192,45 @@ components:
 
     CreateEditResponse:
       type: object
+      title: Edit
+      deprecated: true
       properties:
-        object:
-          type: string
-        created:
-          type: integer
         choices:
           type: array
+          description: A list of edit choices. Can be more than one if `n` is greater than 1.
           items:
             type: object
+            required:
+              - text
+              - index
+              - finish_reason
             properties:
-              text:
-                type: string
-              index:
-                type: integer
-              logprobs:
-                type: object
-                nullable: true
-                properties:
-                  tokens:
-                    type: array
-                    items:
-                      type: string
-                  token_logprobs:
-                    type: array
-                    items:
-                      type: number
-                  top_logprobs:
-                    type: array
-                    items:
-                      type: object
-                  text_offset:
-                    type: array
-                    items:
-                      type: integer
               finish_reason:
                 type: string
+                description: *completion_finish_reason_description
+                enum: ["stop", "length"]
+              index:
+                type: integer
+                description: The index of the choice in the list of choices.
+              text:
+                type: string
+                description: The edited result.
+        object:
+          type: string
+          description: The object type, which is always `edit`.
+        created:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the edit was created.
         usage:
-          type: object
-          properties:
-            prompt_tokens:
-              type: integer
-            completion_tokens:
-              type: integer
-            total_tokens:
-              type: integer
-          required:
-            - prompt_tokens
-            - completion_tokens
-            - total_tokens
+          $ref: "#/components/schemas/CompletionUsage"
       required:
         - object
         - created
         - choices
         - usage
+      x-oaiMeta:
+        name: The edit object
+        example: *edit_example
 
     CreateImageRequest:
       type: object
@@ -2687,13 +3247,6 @@ components:
           example: 1
           nullable: true
           description: The number of images to generate. Must be between 1 and 10.
-        size: &images_size
-          type: string
-          enum: ["256x256", "512x512", "1024x1024"]
-          default: "1024x1024"
-          example: "1024x1024"
-          nullable: true
-          description: The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024`.
         response_format: &images_response_format
           type: string
           enum: ["url", "b64_json"]
@@ -2701,6 +3254,13 @@ components:
           example: "url"
           nullable: true
           description: The format in which the generated images are returned. Must be one of `url` or `b64_json`.
+        size: &images_size
+          type: string
+          enum: ["256x256", "512x512", "1024x1024"]
+          default: "1024x1024"
+          example: "1024x1024"
+          nullable: true
+          description: The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024`.
         user: *end_user_param_configuration
       required:
         - prompt
@@ -2712,15 +3272,27 @@ components:
         data:
           type: array
           items:
-            type: object
-            properties:
-              url:
-                type: string
-              b64_json:
-                type: string
+            $ref: "#/components/schemas/Image"
       required:
         - created
         - data
+
+    Image:
+      type: object
+      description: Represents the url or the content of an image generated by the OpenAI API.
+      properties:
+        b64_json:
+          type: string
+          description: The base64-encoded JSON of the generated image, if `response_format` is `b64_json`.
+        url:
+          type: string
+          description: The URL of the generated image, if `response_format` is `url` (default).
+      x-oaiMeta:
+        name: The image object
+        example: |
+          {
+            "url": "..."
+          }
 
     CreateImageEditRequest:
       type: object
@@ -2729,14 +3301,14 @@ components:
           description: The image to edit. Must be a valid PNG file, less than 4MB, and square. If mask is not provided, image must have transparency, which will be used as the mask.
           type: string
           format: binary
-        mask:
-          description: An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where `image` should be edited. Must be a valid PNG file, less than 4MB, and have the same dimensions as `image`.
-          type: string
-          format: binary
         prompt:
           description: A text description of the desired image(s). The maximum length is 1000 characters.
           type: string
           example: "A cute baby sea otter wearing a beret"
+        mask:
+          description: An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where `image` should be edited. Must be a valid PNG file, less than 4MB, and have the same dimensions as `image`.
+          type: string
+          format: binary
         n: *images_n
         size: *images_size
         response_format: *images_response_format
@@ -2753,8 +3325,8 @@ components:
           type: string
           format: binary
         n: *images_n
-        size: *images_size
         response_format: *images_response_format
+        size: *images_size
         user: *end_user_param_configuration
       required:
         - image
@@ -2778,73 +3350,130 @@ components:
             Two content moderations models are available: `text-moderation-stable` and `text-moderation-latest`.
 
             The default is `text-moderation-latest` which will be automatically upgraded over time. This ensures you are always using our most accurate model. If you use `text-moderation-stable`, we will provide advanced notice before updating the model. Accuracy of `text-moderation-stable` may be slightly lower than for `text-moderation-latest`.
-          type: string
           nullable: false
           default: "text-moderation-latest"
           example: "text-moderation-stable"
+          anyOf:
+            - type: string
+            - type: string
+              enum: ["text-moderation-latest", "text-moderation-stable"]
+          x-oaiTypeLabel: string
       required:
         - input
 
     CreateModerationResponse:
       type: object
+      description: Represents policy compliance report by OpenAI's content moderation model against a given input.
       properties:
         id:
           type: string
+          description: The unique identifier for the moderation request.
         model:
           type: string
+          description: The model used to generate the moderation results.
         results:
           type: array
+          description: A list of moderation objects.
           items:
             type: object
             properties:
               flagged:
                 type: boolean
+                description: Whether the content violates [OpenAI's usage policies](/policies/usage-policies).
               categories:
                 type: object
+                description: A list of the categories, and whether they are flagged or not.
                 properties:
                   hate:
                     type: boolean
+                    description: Content that expresses, incites, or promotes hate based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste. Hateful content aimed at non-protected groups (e.g., chess players) is harrassment.
                   hate/threatening:
                     type: boolean
+                    description: Hateful content that also includes violence or serious harm towards the targeted group based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste.
+                  harassment:
+                    type: boolean
+                    description: Content that expresses, incites, or promotes harassing language towards any target.
+                  harassment/threatening:
+                    type: boolean
+                    description: Harassment content that also includes violence or serious harm towards any target.
                   self-harm:
                     type: boolean
+                    description: Content that promotes, encourages, or depicts acts of self-harm, such as suicide, cutting, and eating disorders.
+                  self-harm/intent:
+                    type: boolean
+                    description: Content where the speaker expresses that they are engaging or intend to engage in acts of self-harm, such as suicide, cutting, and eating disorders.
+                  self-harm/instructions:
+                    type: boolean
+                    description: Content that encourages performing acts of self-harm, such as suicide, cutting, and eating disorders, or that gives instructions or advice on how to commit such acts.
                   sexual:
                     type: boolean
+                    description: Content meant to arouse sexual excitement, such as the description of sexual activity, or that promotes sexual services (excluding sex education and wellness).
                   sexual/minors:
                     type: boolean
+                    description: Sexual content that includes an individual who is under 18 years old.
                   violence:
                     type: boolean
+                    description: Content that depicts death, violence, or physical injury.
                   violence/graphic:
                     type: boolean
+                    description: Content that depicts death, violence, or physical injury in graphic detail.
                 required:
                   - hate
                   - hate/threatening
+                  - harassment
+                  - harassment/threatening
                   - self-harm
+                  - self-harm/intent
+                  - self-harm/instructions
                   - sexual
                   - sexual/minors
                   - violence
                   - violence/graphic
               category_scores:
                 type: object
+                description: A list of the categories along with their scores as predicted by model.
                 properties:
                   hate:
                     type: number
+                    description: The score for the category 'hate'.
                   hate/threatening:
                     type: number
+                    description: The score for the category 'hate/threatening'.
+                  harassment:
+                    type: number
+                    description: The score for the category 'harassment'.
+                  harassment/threatening:
+                    type: number
+                    description: The score for the category 'harassment/threatening'.
                   self-harm:
                     type: number
+                    description: The score for the category 'self-harm'.
+                  self-harm/intent:
+                    type: number
+                    description: The score for the category 'self-harm/intent'.
+                  self-harm/instructions:
+                    type: number
+                    description: The score for the category 'self-harm/instructions'.
                   sexual:
                     type: number
+                    description: The score for the category 'sexual'.
                   sexual/minors:
                     type: number
+                    description: The score for the category 'sexual/minors'.
                   violence:
                     type: number
+                    description: The score for the category 'violence'.
                   violence/graphic:
                     type: number
+                    description: The score for the category 'violence/graphic'.
                 required:
                   - hate
                   - hate/threatening
+                  - harassment
+                  - harassment/threatening
                   - self-harm
+                  - self-harm/intent
+                  - self-harm/instructions
                   - sexual
                   - sexual/minors
                   - violence
@@ -2857,85 +3486,19 @@ components:
         - id
         - model
         - results
-
-    CreateSearchRequest:
-      type: object
-      properties:
-        query:
-          description: Query to search against the documents.
-          type: string
-          example: "the president"
-          minLength: 1
-        documents:
-          description: |
-            Up to 200 documents to search over, provided as a list of strings.
-
-            The maximum document length (in tokens) is 2034 minus the number of tokens in the query.
-
-            You should specify either `documents` or a `file`, but not both.
-          type: array
-          minItems: 1
-          maxItems: 200
-          items:
-            type: string
-          nullable: true
-          example: "['White House', 'hospital', 'school']"
-        file:
-          description: |
-            The ID of an uploaded file that contains documents to search over.
-
-            You should specify either `documents` or a `file`, but not both.
-          type: string
-          nullable: true
-        max_rerank:
-          description: |
-            The maximum number of documents to be re-ranked and returned by search.
-
-            This flag only takes effect when `file` is set.
-          type: integer
-          minimum: 1
-          default: 200
-          nullable: true
-        return_metadata: &return_metadata_configuration
-          description: |
-            A special boolean flag for showing metadata. If set to `true`, each document entry in the returned JSON will contain a "metadata" field.
-
-            This flag only takes effect when `file` is set.
-          type: boolean
-          default: false
-          nullable: true
-        user: *end_user_param_configuration
-      required:
-        - query
-
-    CreateSearchResponse:
-      type: object
-      properties:
-        object:
-          type: string
-        model:
-          type: string
-        data:
-          type: array
-          items:
-            type: object
-            properties:
-              object:
-                type: string
-              document:
-                type: integer
-              score:
-                type: number
+      x-oaiMeta:
+        name: The moderation object
+        example: *moderation_example
 
     ListFilesResponse:
       type: object
       properties:
-        object:
-          type: string
         data:
           type: array
           items:
             $ref: "#/components/schemas/OpenAIFile"
+        object:
+          type: string
       required:
         - object
         - data
@@ -2946,17 +3509,16 @@ components:
       properties:
         file:
           description: |
-            Name of the [JSON Lines](https://jsonlines.readthedocs.io/en/latest/) file to be uploaded.
+            The file object (not file name) to be uploaded.
 
-            If the `purpose` is set to "fine-tune", each line is a JSON record with "prompt" and "completion" fields representing your [training examples](/docs/guides/fine-tuning/prepare-training-data).
+            If the `purpose` is set to "fine-tune", the file will be used for fine-tuning.
           type: string
           format: binary
         purpose:
           description: |
-            The intended purpose of the uploaded documents.
+            The intended purpose of the uploaded file.
 
-            Use "fine-tune" for [Fine-tuning](/docs/api-reference/fine-tunes). This allows us to validate the format of the uploaded file.
-
+            Use "fine-tune" for [fine-tuning](/docs/api-reference/fine-tuning). This allows us to validate the format of the uploaded file is correct for fine-tuning.
           type: string
       required:
         - file
@@ -2976,247 +3538,86 @@ components:
         - object
         - deleted
 
-    CreateAnswerRequest:
+    CreateFineTuningJobRequest:
       type: object
-      additionalProperties: false
       properties:
         model:
-          description: ID of the model to use for completion. You can select one of `ada`, `babbage`, `curie`, or `davinci`.
-          type: string
-        question:
-          description: Question to get answered.
-          type: string
-          minLength: 1
-          example: "What is the capital of Japan?"
-        examples:
-          description: List of (question, answer) pairs that will help steer the model towards the tone and answer format you'd like. We recommend adding 2 to 3 examples.
-          type: array
-          minItems: 1
-          maxItems: 200
-          items:
-            type: array
-            minItems: 2
-            maxItems: 2
-            items:
-              type: string
-              minLength: 1
-          example: "[['What is the capital of Canada?', 'Ottawa'], ['Which province is Ottawa in?', 'Ontario']]"
-        examples_context:
-          description: A text snippet containing the contextual information used to generate the answers for the `examples` you provide.
-          type: string
-          example: "Ottawa, Canada's capital, is located in the east of southern Ontario, near the city of Montréal and the U.S. border."
-        documents:
           description: |
-            List of documents from which the answer for the input `question` should be derived. If this is an empty list, the question will be answered based on the question-answer examples.
-
-            You should specify either `documents` or a `file`, but not both.
-          type: array
-          maxItems: 200
-          items:
-            type: string
-          example: "['Japan is an island country in East Asia, located in the northwest Pacific Ocean.', 'Tokyo is the capital and most populous prefecture of Japan.']"
-          nullable: true
-        file:
-          description: |
-            The ID of an uploaded file that contains documents to search over. See [upload file](/docs/api-reference/files/upload) for how to upload a file of the desired format and purpose.
-
-            You should specify either `documents` or a `file`, but not both.
-          type: string
-          nullable: true
-        search_model: &search_model_configuration
-          description: ID of the model to use for [Search](/docs/api-reference/searches/create). You can select one of `ada`, `babbage`, `curie`, or `davinci`.
-          type: string
-          default: ada
-          nullable: true
-        max_rerank:
-          description: The maximum number of documents to be ranked by [Search](/docs/api-reference/searches/create) when using `file`. Setting it to a higher value leads to improved accuracy but with increased latency and cost.
-          type: integer
-          default: 200
-          nullable: true
-        temperature:
-          description: What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
-          type: number
-          default: 0
-          nullable: true
-        logprobs: &context_completions_logprobs_configuration
-          type: integer
-          minimum: 0
-          maximum: 5
-          default: null
-          nullable: true
-          description: |
-            Include the log probabilities on the `logprobs` most likely tokens, as well the chosen tokens. For example, if `logprobs` is 5, the API will return a list of the 5 most likely tokens. The API will always return the `logprob` of the sampled token, so there may be up to `logprobs+1` elements in the response.
-
-            The maximum value for `logprobs` is 5.
-
-            When `logprobs` is set, `completion` will be automatically added into `expand` to get the logprobs.
-        max_tokens:
-          description: The maximum number of tokens allowed for the generated answer
-          type: integer
-          default: 16
-          nullable: true
-        stop:
-          description: *completions_stop_description
-          default: null
-          oneOf:
+            The name of the model to fine-tune. You can select one of the
+            [supported models](/docs/guides/fine-tuning/what-models-can-be-fine-tuned).
+          example: "gpt-3.5-turbo"
+          anyOf:
             - type: string
-              default: <|endoftext|>
-              example: "\n"
-            - type: array
-              minItems: 1
-              maxItems: 4
-              items:
-                type: string
-                example: '["\n"]'
-          nullable: true
-        n:
-          description: How many answers to generate for each question.
-          type: integer
-          minimum: 1
-          maximum: 10
-          default: 1
-          nullable: true
-        logit_bias: *completions_logit_bias
-        return_metadata: *return_metadata_configuration
-        return_prompt: &return_prompt_configuration
-          description: If set to `true`, the returned JSON will include a "prompt" field containing the final prompt that was used to request a completion. This is mainly useful for debugging purposes.
-          type: boolean
-          default: false
-          nullable: true
-        expand: &expand_configuration
-          description: If an object name is in the list, we provide the full information of the object; otherwise, we only provide the object ID. Currently we support `completion` and `file` objects for expansion.
-          type: array
-          items: {}
-          nullable: true
-          default: []
-        user: *end_user_param_configuration
-      required:
-        - model
-        - question
-        - examples
-        - examples_context
+            - type: string
+              enum: ["babbage-002", "davinci-002", "gpt-3.5-turbo"]
+          x-oaiTypeLabel: string
+        training_file:
+          description: |
+            The ID of an uploaded file that contains training data.
 
-    CreateAnswerResponse:
-      type: object
-      properties:
-        object:
-          type: string
-        model:
-          type: string
-        search_model:
-          type: string
-        completion:
-          type: string
-        answers:
-          type: array
-          items:
-            type: string
-        selected_documents:
-          type: array
-          items:
-            type: object
-            properties:
-              document:
-                type: integer
-              text:
-                type: string
+            See [upload file](/docs/api-reference/files/upload) for how to upload a file.
 
-    CreateClassificationRequest:
-      type: object
-      additionalProperties: false
-      properties:
-        model: *model_configuration
-        query:
-          description: Query to be classified.
+            Your dataset must be formatted as a JSONL file. Additionally, you must upload your file with the purpose `fine-tune`.
+
+            See the [fine-tuning guide](/docs/guides/fine-tuning) for more details.
+          type: string
+          example: "file-abc123"
+        hyperparameters:
+          type: object
+          description: The hyperparameters used for the fine-tuning job.
+          properties:
+            n_epochs:
+              description: |
+                The number of epochs to train the model for. An epoch refers to one
+                full cycle through the training dataset.
+              oneOf:
+                - type: string
+                  enum: [auto]
+                - type: integer
+                  minimum: 1
+                  maximum: 50
+              default: auto
+        suffix:
+          description: |
+            A string of up to 18 characters that will be added to your fine-tuned model name.
+
+            For example, a `suffix` of "custom-model-name" would produce a model name like `ft:gpt-3.5-turbo:openai:custom-model-name:7p4lURel`.
           type: string
           minLength: 1
-          example: "The plot is not very attractive."
-        examples:
-          description: |
-            A list of examples with labels, in the following format:
-
-            `[["The movie is so interesting.", "Positive"], ["It is quite boring.", "Negative"], ...]`
-
-            All the label strings will be normalized to be capitalized.
-
-            You should specify either `examples` or `file`, but not both.
-          type: array
-          minItems: 2
-          maxItems: 200
-          items:
-            type: array
-            minItems: 2
-            maxItems: 2
-            items:
-              type: string
-              minLength: 1
-          example: "[['Do not see this film.', 'Negative'], ['Smart, provocative and blisteringly funny.', 'Positive']]"
+          maxLength: 40
+          default: null
           nullable: true
-        file:
+        validation_file:
           description: |
-            The ID of the uploaded file that contains training examples. See [upload file](/docs/api-reference/files/upload) for how to upload a file of the desired format and purpose.
+            The ID of an uploaded file that contains validation data.
 
-            You should specify either `examples` or `file`, but not both.
+            If you provide this file, the data is used to generate validation
+            metrics periodically during fine-tuning. These metrics can be viewed in
+            the fine-tuning results file.
+            The same data should not be present in both train and validation files.
+
+            Your dataset must be formatted as a JSONL file. You must upload your file with the purpose `fine-tune`.
+
+            See the [fine-tuning guide](/docs/guides/fine-tuning) for more details.
           type: string
           nullable: true
-        labels:
-          description: The set of categories being classified. If not specified, candidate labels will be automatically collected from the examples you provide. All the label strings will be normalized to be capitalized.
-          type: array
-          minItems: 2
-          maxItems: 200
-          default: null
-          items:
-            type: string
-          example: ["Positive", "Negative"]
-          nullable: true
-        search_model: *search_model_configuration
-        temperature:
-          description: What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
-          type: number
-          minimum: 0
-          maximum: 2
-          default: 0
-          nullable: true
-          example: 0
-        logprobs: *context_completions_logprobs_configuration
-        max_examples:
-          description: The maximum number of examples to be ranked by [Search](/docs/api-reference/searches/create) when using `file`. Setting it to a higher value leads to improved accuracy but with increased latency and cost.
-          type: integer
-          default: 200
-          nullable: true
-        logit_bias: *completions_logit_bias
-        return_prompt: *return_prompt_configuration
-        return_metadata: *return_metadata_configuration
-        expand: *expand_configuration
-        user: *end_user_param_configuration
+          example: "file-abc123"
       required:
         - model
-        - query
+        - training_file
 
-    CreateClassificationResponse:
+    ListFineTuningJobEventsResponse:
       type: object
       properties:
-        object:
-          type: string
-        model:
-          type: string
-        search_model:
-          type: string
-        completion:
-          type: string
-        label:
-          type: string
-        selected_examples:
+        data:
           type: array
           items:
-            type: object
-            properties:
-              document:
-                type: integer
-              text:
-                type: string
-              label:
-                type: string
+            $ref: "#/components/schemas/FineTuningJobEvent"
+        object:
+          type: string
+      required:
+        - object
+        - data
 
     CreateFineTuneRequest:
       type: object
@@ -3231,42 +3632,9 @@ components:
             example is a JSON object with the keys "prompt" and "completion".
             Additionally, you must upload your file with the purpose `fine-tune`.
 
-            See the [fine-tuning guide](/docs/guides/fine-tuning/creating-training-data) for more details.
+            See the [fine-tuning guide](/docs/guides/legacy-fine-tuning/creating-training-data) for more details.
           type: string
-          example: "file-ajSREls59WBbvgSzJSVWxMCB"
-        validation_file:
-          description: |
-            The ID of an uploaded file that contains validation data.
-
-            If you provide this file, the data is used to generate validation
-            metrics periodically during fine-tuning. These metrics can be viewed in
-            the [fine-tuning results file](/docs/guides/fine-tuning/analyzing-your-fine-tuned-model).
-            Your train and validation data should be mutually exclusive.
-
-            Your dataset must be formatted as a JSONL file, where each validation
-            example is a JSON object with the keys "prompt" and "completion".
-            Additionally, you must upload your file with the purpose `fine-tune`.
-
-            See the [fine-tuning guide](/docs/guides/fine-tuning/creating-training-data) for more details.
-          type: string
-          nullable: true
-          example: "file-XjSREls59WBbvgSzJSVWxMCa"
-        model:
-          description: |
-            The name of the base model to fine-tune. You can select one of "ada",
-            "babbage", "curie", "davinci", or a fine-tuned model created after 2022-04-21.
-            To learn more about these models, see the
-            [Models](https://platform.openai.com/docs/models) documentation.
-          default: "curie"
-          type: string
-          nullable: true
-        n_epochs:
-          description: |
-            The number of epochs to train the model for. An epoch refers to one
-            full cycle through the training dataset.
-          default: 4
-          type: integer
-          nullable: true
+          example: "file-abc123"
         batch_size:
           description: |
             The batch size to use for training. The batch size is the number of
@@ -3279,45 +3647,21 @@ components:
           default: null
           type: integer
           nullable: true
-        learning_rate_multiplier:
+        classification_betas:
           description: |
-            The learning rate multiplier to use for training.
-            The fine-tuning learning rate is the original learning rate used for
-            pretraining multiplied by this value.
+            If this is provided, we calculate F-beta scores at the specified
+            beta values. The F-beta score is a generalization of F-1 score.
+            This is only used for binary classification.
 
-            By default, the learning rate multiplier is the 0.05, 0.1, or 0.2
-            depending on final `batch_size` (larger learning rates tend to
-            perform better with larger batch sizes). We recommend experimenting
-            with values in the range 0.02 to 0.2 to see what produces the best
-            results.
+            With a beta of 1 (i.e. the F-1 score), precision and recall are
+            given the same weight. A larger beta score puts more weight on
+            recall and less on precision. A smaller beta score puts more weight
+            on precision and less on recall.
+          type: array
+          items:
+            type: number
+          example: [0.6, 1, 1.5, 2]
           default: null
-          type: number
-          nullable: true
-        prompt_loss_weight:
-          description: |
-            The weight to use for loss on the prompt tokens. This controls how
-            much the model tries to learn to generate the prompt (as compared
-            to the completion which always has a weight of 1.0), and can add
-            a stabilizing effect to training when completions are short.
-
-            If prompts are extremely long (relative to completions), it may make
-            sense to reduce this weight so as to avoid over-prioritizing
-            learning the prompt.
-          default: 0.01
-          type: number
-          nullable: true
-        compute_classification_metrics:
-          description: |
-            If set, we calculate classification-specific metrics such as accuracy
-            and F-1 score using the validation set at the end of every epoch.
-            These metrics can be viewed in the [results file](/docs/guides/fine-tuning/analyzing-your-fine-tuned-model).
-
-            In order to compute classification metrics, you must provide a
-            `validation_file`. Additionally, you must
-            specify `classification_n_classes` for multiclass classification or
-            `classification_positive_class` for binary classification.
-          type: boolean
-          default: false
           nullable: true
         classification_n_classes:
           description: |
@@ -3336,21 +3680,74 @@ components:
           type: string
           default: null
           nullable: true
-        classification_betas:
+        compute_classification_metrics:
           description: |
-            If this is provided, we calculate F-beta scores at the specified
-            beta values. The F-beta score is a generalization of F-1 score.
-            This is only used for binary classification.
+            If set, we calculate classification-specific metrics such as accuracy
+            and F-1 score using the validation set at the end of every epoch.
+            These metrics can be viewed in the [results file](/docs/guides/legacy-fine-tuning/analyzing-your-fine-tuned-model).
 
-            With a beta of 1 (i.e. the F-1 score), precision and recall are
-            given the same weight. A larger beta score puts more weight on
-            recall and less on precision. A smaller beta score puts more weight
-            on precision and less on recall.
-          type: array
-          items:
-            type: number
-          example: [0.6, 1, 1.5, 2]
+            In order to compute classification metrics, you must provide a
+            `validation_file`. Additionally, you must
+            specify `classification_n_classes` for multiclass classification or
+            `classification_positive_class` for binary classification.
+          type: boolean
+          default: false
+          nullable: true
+        hyperparameters:
+          type: object
+          description: The hyperparameters used for the fine-tuning job.
+          properties:
+            n_epochs:
+              description: |
+                The number of epochs to train the model for. An epoch refers to one
+                full cycle through the training dataset.
+              oneOf:
+                - type: string
+                  enum: [auto]
+                - type: integer
+                  minimum: 1
+                  maximum: 50
+              default: auto
+        learning_rate_multiplier:
+          description: |
+            The learning rate multiplier to use for training.
+            The fine-tuning learning rate is the original learning rate used for
+            pretraining multiplied by this value.
+
+            By default, the learning rate multiplier is the 0.05, 0.1, or 0.2
+            depending on final `batch_size` (larger learning rates tend to
+            perform better with larger batch sizes). We recommend experimenting
+            with values in the range 0.02 to 0.2 to see what produces the best
+            results.
           default: null
+          type: number
+          nullable: true
+        model:
+          description: |
+            The name of the base model to fine-tune. You can select one of "ada",
+            "babbage", "curie", "davinci", or a fine-tuned model created after 2022-04-21 and before 2023-08-22.
+            To learn more about these models, see the
+            [Models](/docs/models) documentation.
+          default: "curie"
+          example: "curie"
+          nullable: true
+          anyOf:
+            - type: string
+            - type: string
+              enum: ["ada", "babbage", "curie", "davinci"]
+          x-oaiTypeLabel: string
+        prompt_loss_weight:
+          description: |
+            The weight to use for loss on the prompt tokens. This controls how
+            much the model tries to learn to generate the prompt (as compared
+            to the completion which always has a weight of 1.0), and can add
+            a stabilizing effect to training when completions are short.
+
+            If prompts are extremely long (relative to completions), it may make
+            sense to reduce this weight so as to avoid over-prioritizing
+            learning the prompt.
+          default: 0.01
+          type: number
           nullable: true
         suffix:
           description: |
@@ -3362,18 +3759,35 @@ components:
           maxLength: 40
           default: null
           nullable: true
+        validation_file:
+          description: |
+            The ID of an uploaded file that contains validation data.
+
+            If you provide this file, the data is used to generate validation
+            metrics periodically during fine-tuning. These metrics can be viewed in
+            the [fine-tuning results file](/docs/guides/legacy-fine-tuning/analyzing-your-fine-tuned-model).
+            Your train and validation data should be mutually exclusive.
+
+            Your dataset must be formatted as a JSONL file, where each validation
+            example is a JSON object with the keys "prompt" and "completion".
+            Additionally, you must upload your file with the purpose `fine-tune`.
+
+            See the [fine-tuning guide](/docs/guides/legacy-fine-tuning/creating-training-data) for more details.
+          type: string
+          nullable: true
+          example: "file-abc123"
       required:
         - training_file
 
     ListFineTunesResponse:
       type: object
       properties:
-        object:
-          type: string
         data:
           type: array
           items:
             $ref: "#/components/schemas/FineTune"
+        object:
+          type: string
       required:
         - object
         - data
@@ -3381,12 +3795,12 @@ components:
     ListFineTuneEventsResponse:
       type: object
       properties:
-        object:
-          type: string
         data:
           type: array
           items:
             $ref: "#/components/schemas/FineTuneEvent"
+        object:
+          type: string
       required:
         - object
         - data
@@ -3395,16 +3809,16 @@ components:
       type: object
       additionalProperties: false
       properties:
-        model: *model_configuration
         input:
           description: |
-            Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. Each input must not exceed the max input tokens for the model (8191 tokens for `text-embedding-ada-002`). [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb) for counting tokens.
+            Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `text-embedding-ada-002`) and cannot be an empty string. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.
           example: "The quick brown fox jumped over the lazy dog"
           oneOf:
             - type: string
               default: ""
               example: "This is a test."
             - type: array
+              minItems: 1
               items:
                 type: string
                 default: ""
@@ -3422,6 +3836,20 @@ components:
                 items:
                   type: integer
               example: "[[1212, 318, 257, 1332, 13]]"
+        model:
+          description: *model_description
+          example: "text-embedding-ada-002"
+          anyOf:
+            - type: string
+            - type: string
+              enum: ["text-embedding-ada-002"]
+          x-oaiTypeLabel: string
+        encoding_format:
+          description: "The format to return the embeddings in. Can be either `float` or [`base64`](https://pypi.org/project/pybase64/)."
+          example: "float"
+          default: "float"
+          type: string
+          enum: ["float", "base64"]
         user: *end_user_param_configuration
       required:
         - model
@@ -3430,34 +3858,27 @@ components:
     CreateEmbeddingResponse:
       type: object
       properties:
-        object:
-          type: string
-        model:
-          type: string
         data:
           type: array
+          description: The list of embeddings generated by the model.
           items:
-            type: object
-            properties:
-              index:
-                type: integer
-              object:
-                type: string
-              embedding:
-                type: array
-                items:
-                  type: number
-            required:
-              - index
-              - object
-              - embedding
+            $ref: "#/components/schemas/Embedding"
+        model:
+          type: string
+          description: The name of the model used to generate the embedding.
+        object:
+          type: string
+          description: The object type, which is always "embedding".
         usage:
           type: object
+          description: The usage information for the request.
           properties:
             prompt_tokens:
               type: integer
+              description: The number of tokens used by the prompt.
             total_tokens:
               type: integer
+              description: The total number of tokens used by the request.
           required:
             - prompt_tokens
             - total_tokens
@@ -3473,13 +3894,22 @@ components:
       properties:
         file:
           description: |
-            The audio file object (not file name) to transcribe, in one of these formats: mp3, mp4, mpeg, mpga, m4a, wav, or webm.
+            The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
           type: string
           x-oaiTypeLabel: file
           format: binary
         model:
           description: |
             ID of the model to use. Only `whisper-1` is currently available.
+          example: whisper-1
+          anyOf:
+            - type: string
+            - type: string
+              enum: ["whisper-1"]
+          x-oaiTypeLabel: string
+        language:
+          description: |
+            The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format will improve accuracy and latency.
           type: string
         prompt:
           description: |
@@ -3489,16 +3919,18 @@ components:
           description: |
             The format of the transcript output, in one of these options: json, text, srt, verbose_json, or vtt.
           type: string
+          enum:
+            - json
+            - text
+            - srt
+            - verbose_json
+            - vtt
           default: json
         temperature:
           description: |
             The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use [log probability](https://en.wikipedia.org/wiki/Log_probability) to automatically increase the temperature until certain thresholds are hit.
           type: number
           default: 0
-        language:
-          description: |
-            The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format will improve accuracy and latency.
-          type: string
       required:
         - file
         - model
@@ -3518,14 +3950,19 @@ components:
       properties:
         file:
           description: |
-            The audio file object (not file name) translate, in one of these formats: mp3, mp4, mpeg, mpga, m4a, wav, or webm.
+            The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
           type: string
           x-oaiTypeLabel: file
           format: binary
         model:
           description: |
             ID of the model to use. Only `whisper-1` is currently available.
-          type: string
+          example: whisper-1
+          anyOf:
+            - type: string
+            - type: string
+              enum: ["whisper-1"]
+          x-oaiTypeLabel: string
         prompt:
           description: |
             An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text/prompting) should be in English.
@@ -3553,61 +3990,62 @@ components:
       required:
         - text
 
-    Engine:
-      title: Engine
-      properties:
-        id:
-          type: string
-        object:
-          type: string
-        created:
-          type: integer
-          nullable: true
-        ready:
-          type: boolean
-      required:
-        - id
-        - object
-        - created
-        - ready
-
     Model:
       title: Model
+      description: Describes an OpenAI model offering that can be used with the API.
       properties:
         id:
           type: string
-        object:
-          type: string
+          description: The model identifier, which can be referenced in the API endpoints.
         created:
           type: integer
+          description: The Unix timestamp (in seconds) when the model was created.
+        object:
+          type: string
+          description: The object type, which is always "model".
         owned_by:
           type: string
+          description: The organization that owns the model.
       required:
         - id
         - object
         - created
         - owned_by
+      x-oaiMeta:
+        name: The model object
+        example: *retrieve_model_response
 
     OpenAIFile:
       title: OpenAIFile
+      description: |
+        The `File` object represents a document that has been uploaded to OpenAI.
       properties:
         id:
           type: string
-        object:
-          type: string
+          description: The file identifier, which can be referenced in the API endpoints.
         bytes:
           type: integer
+          description: The size of the file in bytes.
         created_at:
           type: integer
+          description: The Unix timestamp (in seconds) for when the file was created.
         filename:
           type: string
+          description: The name of the file.
+        object:
+          type: string
+          description: The object type, which is always "file".
         purpose:
           type: string
+          description: The intended purpose of the file. Currently, only "fine-tune" is supported.
         status:
           type: string
+          description: The current status of the file, which can be either `uploaded`, `processed`, `pending`, `error`, `deleting` or `deleted`.
         status_details:
-          type: object
+          type: string
           nullable: true
+          description: |
+            Additional details about the status of the file. If the file is in the `error` state, this will include a message describing the error.
       required:
         - id
         - object
@@ -3615,158 +4053,565 @@ components:
         - created_at
         - filename
         - purpose
+        - format
+      x-oaiMeta:
+        name: The file object
+        example: |
+          {
+            "id": "file-abc123",
+            "object": "file",
+            "bytes": 120000,
+            "created_at": 1677610602,
+            "filename": "my_file.jsonl",
+            "purpose": "fine-tune",
+            "status": "uploaded",
+            "status_details": null
+          }
+    Embedding:
+      type: object
+      description: |
+        Represents an embedding vector returned by embedding endpoint.
+      properties:
+        index:
+          type: integer
+          description: The index of the embedding in the list of embeddings.
+        embedding:
+          type: array
+          description: |
+            The embedding vector, which is a list of floats. The length of vector depends on the model as listed in the [embedding guide](/docs/guides/embeddings).
+          items:
+            type: number
+        object:
+          type: string
+          description: The object type, which is always "embedding".
+      required:
+        - index
+        - object
+        - embedding
+      x-oaiMeta:
+        name: The embedding object
+        example: |
+          {
+            "object": "embedding",
+            "embedding": [
+              0.0023064255,
+              -0.009327292,
+              .... (1536 floats total for ada-002)
+              -0.0028842222,
+            ],
+            "index": 0
+          }
 
-    FineTune:
-      title: FineTune
+    FineTuningJob:
+      type: object
+      title: FineTuningJob
+      description: |
+        The `fine_tuning.job` object represents a fine-tuning job that has been created through the API.
       properties:
         id:
           type: string
-        object:
-          type: string
+          description: The object identifier, which can be referenced in the API endpoints.
         created_at:
           type: integer
-        updated_at:
-          type: integer
-        model:
-          type: string
+          description: The Unix timestamp (in seconds) for when the fine-tuning job was created.
+        error:
+          type: object
+          nullable: true
+          description: For fine-tuning jobs that have `failed`, this will contain more information on the cause of the failure.
+          properties:
+            code:
+              type: string
+              description: A machine-readable error code.
+            message:
+              type: string
+              description: A human-readable error message.
+            param:
+              type: string
+              description: The parameter that was invalid, usually `training_file` or `validation_file`. This field will be null if the failure was not parameter-specific.
+              nullable: true
+          required:
+            - code
+            - message
+            - param
         fine_tuned_model:
           type: string
           nullable: true
+          description: The name of the fine-tuned model that is being created. The value will be null if the fine-tuning job is still running.
+        finished_at:
+          type: integer
+          nullable: true
+          description: The Unix timestamp (in seconds) for when the fine-tuning job was finished. The value will be null if the fine-tuning job is still running.
+        hyperparameters:
+          type: object
+          description: The hyperparameters used for the fine-tuning job. See the [fine-tuning guide](/docs/guides/fine-tuning) for more details.
+          properties:
+            n_epochs:
+              oneOf:
+                - type: string
+                  enum: [auto]
+                - type: integer
+                  minimum: 1
+                  maximum: 50
+              default: auto
+              description:
+                The number of epochs to train the model for. An epoch refers to one full cycle through the training dataset.
+
+                "auto" decides the optimal number of epochs based on the size of the dataset. If setting the number manually, we support any number between 1 and 50 epochs.
+          required:
+            - n_epochs
+        model:
+          type: string
+          description: The base model that is being fine-tuned.
+        object:
+          type: string
+          description: The object type, which is always "fine_tuning.job".
         organization_id:
           type: string
-        status:
-          type: string
-        hyperparams:
-          type: object
-        training_files:
-          type: array
-          items:
-            $ref: "#/components/schemas/OpenAIFile"
-        validation_files:
-          type: array
-          items:
-            $ref: "#/components/schemas/OpenAIFile"
+          description: The organization that owns the fine-tuning job.
         result_files:
           type: array
+          description: The compiled results file ID(s) for the fine-tuning job. You can retrieve the results with the [Files API](/docs/api-reference/files/retrieve-contents).
           items:
-            $ref: "#/components/schemas/OpenAIFile"
-        events:
-          type: array
-          items:
-            $ref: "#/components/schemas/FineTuneEvent"
+            type: string
+            example: file-abc123
+        status:
+          type: string
+          description: The current status of the fine-tuning job, which can be either `validating_files`, `queued`, `running`, `succeeded`, `failed`, or `cancelled`.
+        trained_tokens:
+          type: integer
+          nullable: true
+          description: The total number of billable tokens processed by this fine-tuning job. The value will be null if the fine-tuning job is still running.
+        training_file:
+          type: string
+          description: The file ID used for training. You can retrieve the training data with the [Files API](/docs/api-reference/files/retrieve-contents).
+        validation_file:
+          type: string
+          nullable: true
+          description: The file ID used for validation. You can retrieve the validation results with the [Files API](/docs/api-reference/files/retrieve-contents).
+      required:
+        - created_at
+        - error
+        - finished_at
+        - fine_tuned_model
+        - hyperparameters
+        - id
+        - model
+        - object
+        - organization_id
+        - result_files
+        - status
+        - trained_tokens
+        - training_file
+        - validation_file
+      x-oaiMeta:
+        name: The fine-tuning job object
+        example: *fine_tuning_example
+    
+    FineTuningJobEvent:
+      type: object
+      description: Fine-tuning job event object
+      properties:
+        id:
+          type: string
+        created_at:
+          type: integer
+        level:
+          type: string
+          enum: ["info", "warn", "error"]
+        message:
+          type: string
+        object:
+          type: string
       required:
         - id
         - object
         - created_at
-        - updated_at
-        - model
-        - fine_tuned_model
-        - organization_id
-        - status
-        - hyperparams
-        - training_files
-        - validation_files
-        - result_files
+        - level
+        - message
+      x-oaiMeta:
+        name: The fine-tuning job event object
+        example: |
+          {
+            "object": "event",
+            "id": "ftevent-abc123"
+            "created_at": 1677610602,
+            "level": "info",
+            "message": "Created fine-tuning job"
+          }
 
-    FineTuneEvent:
-      title: FineTuneEvent
+    FineTune:
+      type: object
+      deprecated: true
+      description: |
+        The `FineTune` object represents a legacy fine-tune job that has been created through the API.
       properties:
+        id:
+          type: string
+          description: The object identifier, which can be referenced in the API endpoints.
+        created_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the fine-tuning job was created.
+        events:
+          type: array
+          description: The list of events that have been observed in the lifecycle of the FineTune job.
+          items:
+            $ref: "#/components/schemas/FineTuneEvent"
+        fine_tuned_model:
+          type: string
+          nullable: true
+          description: The name of the fine-tuned model that is being created.
+        hyperparams:
+          type: object
+          description: The hyperparameters used for the fine-tuning job. See the [fine-tuning guide](/docs/guides/legacy-fine-tuning/hyperparameters) for more details.
+          properties:
+            batch_size:
+              type: integer
+              description: |
+                The batch size to use for training. The batch size is the number of
+                training examples used to train a single forward and backward pass.
+            classification_n_classes:
+              type: integer
+              description: |
+                The number of classes to use for computing classification metrics.
+            classification_positive_class:
+              type: string
+              description: |
+                The positive class to use for computing classification metrics.
+            compute_classification_metrics:
+              type: boolean
+              description: |
+                The classification metrics to compute using the validation dataset at the end of every epoch.
+            learning_rate_multiplier:
+              type: number
+              description: |
+                The learning rate multiplier to use for training.
+            n_epochs:
+              type: integer
+              description: |
+                The number of epochs to train the model for. An epoch refers to one
+                full cycle through the training dataset.
+            prompt_loss_weight:
+              type: number
+              description: |
+                The weight to use for loss on the prompt tokens.
+          required:
+            - batch_size
+            - learning_rate_multiplier
+            - n_epochs
+            - prompt_loss_weight
+        model:
+          type: string
+          description: The base model that is being fine-tuned.
         object:
           type: string
+          description: The object type, which is always "fine-tune".
+        organization_id:
+          type: string
+          description: The organization that owns the fine-tuning job.
+        result_files:
+          type: array
+          description: The compiled results files for the fine-tuning job.
+          items:
+            $ref: "#/components/schemas/OpenAIFile"
+        status:
+          type: string
+          description: The current status of the fine-tuning job, which can be either `created`, `running`, `succeeded`, `failed`, or `cancelled`.
+        training_files:
+          type: array
+          description: The list of files used for training.
+          items:
+            $ref: "#/components/schemas/OpenAIFile"
+        updated_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the fine-tuning job was last updated.
+        validation_files:
+          type: array
+          description: The list of files used for validation.
+          items:
+            $ref: "#/components/schemas/OpenAIFile"
+      required:
+        - created_at
+        - fine_tuned_model
+        - hyperparams
+        - id
+        - model
+        - object
+        - organization_id
+        - result_files
+        - status
+        - training_files
+        - updated_at
+        - validation_files
+      x-oaiMeta:
+        name: The fine-tune object
+        example: *fine_tune_example
+
+    FineTuneEvent:
+      type: object
+      deprecated: true
+      description: Fine-tune event object
+      properties:
         created_at:
           type: integer
         level:
           type: string
         message:
           type: string
+        object:
+          type: string
       required:
         - object
         - created_at
         - level
         - message
+      x-oaiMeta:
+        name: The fine-tune event object
+        example: |
+          {
+            "object": "event",
+            "created_at": 1677610602,
+            "level": "info",
+            "message": "Created fine-tune job"
+          }
+
+    CompletionUsage:
+      type: object
+      description: Usage statistics for the completion request.
+      properties:
+        completion_tokens:
+          type: integer
+          description: Number of tokens in the generated completion.
+        prompt_tokens:
+          type: integer
+          description: Number of tokens in the prompt.
+        total_tokens:
+          type: integer
+          description: Total number of tokens used in the request (prompt + completion).
+      required:
+        - prompt_tokens
+        - completion_tokens
+        - total_tokens
+
+security:
+  - ApiKeyAuth: []
 
 x-oaiMeta:
   groups:
-    - id: models
-      title: Models
-      description: |
-        List and describe the various models available in the API. You can refer to the [Models](/docs/models) documentation to understand what models are available and the differences between them.
-    - id: chat
-      title: Chat
-      description: |
-        Given a list of messages comprising a conversation, the model will return a response.
-    - id: completions
-      title: Completions
-      description: |
-        Given a prompt, the model will return one or more predicted completions, and can also return the probabilities of alternative tokens at each position.
-    - id: edits
-      title: Edits
-      description: |
-        Given a prompt and an instruction, the model will return an edited version of the prompt.
-    - id: images
-      title: Images
-      description: |
-        Given a prompt and/or an input image, the model will generate a new image.
-
-        Related guide: [Image generation](/docs/guides/images)
-    - id: embeddings
-      title: Embeddings
-      description: |
-        Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.
-
-        Related guide: [Embeddings](/docs/guides/embeddings)
+    # > General Notes
+    # The `groups` section is used to generate the API reference pages and navigation, in the same
+    # order listed below. Additionally, each `group` can have a list of `sections`, each of which
+    # will become a navigation subroute and subsection under the group. Each section has:
+    #  - `type`: Currently, either an `endpoint` or `object`, depending on how the section needs to
+    #            be rendered
+    #  - `key`: The reference key that can be used to lookup the section definition
+    #  - `path`: The path (url) of the section, which is used to generate the navigation link.
+    #
+    # > The `object` sections maps to a schema component and the following fields are read for rendering
+    # - `x-oaiMeta.name`: The name of the object, which will become the section title
+    # - `x-oaiMeta.example`: The example object, which will be used to generate the example sample (always JSON)
+    # - `description`: The description of the object, which will be used to generate the section description
+    #
+    # > The `endpoint` section maps to an operation path and the following fields are read for rendering:
+    # - `x-oaiMeta.name`: The name of the endpoint, which will become the section title
+    # - `x-oaiMeta.examples`: The endpoint examples, which can be an object (meaning a single variation, most
+    #                         endpoints, or an array of objects, meaning multiple variations, e.g. the
+    #                         chat completion and completion endpoints, with streamed and non-streamed examples.
+    # - `x-oaiMeta.returns`: text describing what the endpoint returns.
+    # - `summary`: The summary of the endpoint, which will be used to generate the section description
     - id: audio
       title: Audio
       description: |
         Learn how to turn audio into text.
 
         Related guide: [Speech to text](/docs/guides/speech-to-text)
-    - id: files
-      title: Files
+      sections:
+        - type: endpoint
+          key: createTranscription
+          path: createTranscription
+        - type: endpoint
+          key: createTranslation
+          path: createTranslation
+    - id: chat
+      title: Chat
       description: |
-        Files are used to upload documents that can be used with features like [Fine-tuning](/docs/api-reference/fine-tunes).
-    - id: fine-tunes
-      title: Fine-tunes
+        Given a list of messages comprising a conversation, the model will return a response.
+
+        Related guide: [Chat completions](/docs/guides/gpt)
+      sections:
+        - type: object
+          key: CreateChatCompletionResponse
+          path: object
+        - type: object
+          key: CreateChatCompletionStreamResponse
+          path: streaming
+        - type: endpoint
+          key: createChatCompletion
+          path: create
+    - id: completions
+      title: Completions
+      legacy: true
+      description: |
+        Given a prompt, the model will return one or more predicted completions, and can also return the probabilities of alternative tokens at each position. We recommend most users use our Chat completions API. [Learn more](/docs/deprecations/2023-07-06-gpt-and-embeddings)
+
+        Related guide: [Legacy Completions](/docs/guides/gpt/completions-api)
+      sections:
+        - type: object
+          key: CreateCompletionResponse
+          path: object
+        - type: endpoint
+          key: createCompletion
+          path: create
+    - id: embeddings
+      title: Embeddings
+      description: |
+        Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.
+
+        Related guide: [Embeddings](/docs/guides/embeddings)
+      sections:
+        - type: object
+          key: Embedding
+          path: object
+        - type: endpoint
+          key: createEmbedding
+          path: create
+    - id: fine-tuning
+      title: Fine-tuning
       description: |
         Manage fine-tuning jobs to tailor a model to your specific training data.
 
         Related guide: [Fine-tune models](/docs/guides/fine-tuning)
+      sections:
+        - type: object
+          key: FineTuningJob
+          path: object
+        - type: endpoint
+          key: createFineTuningJob
+          path: create
+        - type: endpoint
+          key: listPaginatedFineTuningJobs
+          path: list
+        - type: endpoint
+          key: retrieveFineTuningJob
+          path: retrieve
+        - type: endpoint
+          key: cancelFineTuningJob
+          path: cancel
+        - type: object
+          key: FineTuningJobEvent
+          path: event-object
+        - type: endpoint
+          key: listFineTuningEvents
+          path: list-events
+    - id: files
+      title: Files
+      description: |
+        Files are used to upload documents that can be used with features like [fine-tuning](/docs/api-reference/fine-tuning).
+      sections:
+        - type: object
+          key: OpenAIFile
+          path: object
+        - type: endpoint
+          key: listFiles
+          path: list
+        - type: endpoint
+          key: createFile
+          path: create
+        - type: endpoint
+          key: deleteFile
+          path: delete
+        - type: endpoint
+          key: retrieveFile
+          path: retrieve
+        - type: endpoint
+          key: downloadFile
+          path: retrieve-contents
+    - id: images
+      title: Images
+      description: |
+        Given a prompt and/or an input image, the model will generate a new image.
+
+        Related guide: [Image generation](/docs/guides/images)
+      sections:
+        - type: object
+          key: Image
+          path: object
+        - type: endpoint
+          key: createImage
+          path: create
+        - type: endpoint
+          key: createImageEdit
+          path: createEdit
+        - type: endpoint
+          key: createImageVariation
+          path: createVariation
+    - id: models
+      title: Models
+      description: |
+        List and describe the various models available in the API. You can refer to the [Models](/docs/models) documentation to understand what models are available and the differences between them.
+      sections:
+        - type: object
+          key: Model
+          path: object
+        - type: endpoint
+          key: listModels
+          path: list
+        - type: endpoint
+          key: retrieveModel
+          path: retrieve
+        - type: endpoint
+          key: deleteModel
+          path: delete
     - id: moderations
       title: Moderations
       description: |
         Given a input text, outputs if the model classifies it as violating OpenAI's content policy.
 
         Related guide: [Moderations](/docs/guides/moderation)
-    - id: searches
-      title: Searches
-      warning:
-        title: This endpoint is deprecated and will be removed on December 3rd, 2022
-        message: We’ve developed new methods with better performance. [Learn more](https://help.openai.com/en/articles/6272952-search-transition-guide).
+      sections:
+        - type: object
+          key: CreateModerationResponse
+          path: object
+        - type: endpoint
+          key: createModeration
+          path: create
+    - id: fine-tunes
+      title: Fine-tunes
+      deprecated: true
       description: |
-        Given a query and a set of documents or labels, the model ranks each document based on its semantic similarity to the provided query.
+        Manage legacy fine-tuning jobs to tailor a model to your specific training data.
 
-        Related guide: [Search](/docs/guides/search)
-    - id: classifications
-      title: Classifications
-      warning:
-        title: This endpoint is deprecated and will be removed on December 3rd, 2022
-        message: We’ve developed new methods with better performance. [Learn more](https://help.openai.com/en/articles/6272941-classifications-transition-guide).
+        We recommend transitioning to the updating [fine-tuning API](/docs/guides/fine-tuning)
+      sections:
+        - type: object
+          key: FineTune
+          path: object
+        - type: endpoint
+          key: createFineTune
+          path: create
+        - type: endpoint
+          key: listFineTunes
+          path: list
+        - type: endpoint
+          key: retrieveFineTune
+          path: retrieve
+        - type: endpoint
+          key: cancelFineTune
+          path: cancel
+        - type: object
+          key: FineTuneEvent
+          path: event-object
+        - type: endpoint
+          key: listFineTuneEvents
+          path: list-events
+    - id: edits
+      title: Edits
+      deprecated: true
       description: |
-        Given a query and a set of labeled examples, the model will predict the most likely label for the query. Useful as a drop-in replacement for any ML classification or text-to-label task.
-
-        Related guide: [Classification](/docs/guides/classifications)
-    - id: answers
-      title: Answers
-      warning:
-        title: This endpoint is deprecated and will be removed on December 3rd, 2022
-        message: We’ve developed new methods with better performance. [Learn more](https://help.openai.com/en/articles/6233728-answers-transition-guide).
-      description: |
-        Given a question, a set of documents, and some examples, the API generates an answer to the question based on the information in the set of documents. This is useful for question-answering applications on sources of truth, like company documentation or a knowledge base.
-
-        Related guide: [Question answering](/docs/guides/answers)
-    - id: engines
-      title: Engines
-      description: These endpoints describe and provide access to the various engines available in the API.
-      warning:
-        title: The Engines endpoints are deprecated.
-        message: Please use their replacement, [Models](/docs/api-reference/models), instead. [Learn more](https://help.openai.com/TODO).
+        Given a prompt and an instruction, the model will return an edited version of the prompt.
+      sections:
+        - type: object
+          key: CreateEditResponse
+          path: object
+        - type: endpoint
+          key: createEdit
+          path: create


### PR DESCRIPTION
Sync changes from upstream spec:
- use enums `FinishReason` & `CompletionFinishReason` for `finish_reason` instead of `String`
- Rename struct `Usage` to `CompletionUsage`
- Add field `encoding_format` in `CreateEmbeddingRequest`
- Update `status_detail` field type in `OpenAIFile` from object to `String`
- Rename `ImageData` to `Image` to match spec
- Rename `ImageResponse` to `ImagesResponse` to match spec
- Add new fields in moderation request and response types.
- Update doc comments to match latest spec 
- Add new Fine Tuning APIs
- Mark `Edit` and `FineTunes` to be deprecated
- Update `ChatCompletionFunctionCall` for better DX 