### PR TITLE
Add speech endpoint

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -40,6 +40,7 @@ tracing = "0.1.37"
 derive_builder = "0.12.0"
 async-convert = "1.0.0"
 secrecy = { version = "0.8.0", features=["serde"] }
+bytes = "1.5.0"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/async-openai/README.md
+++ b/async-openai/README.md
@@ -23,7 +23,7 @@
 
 - It's based on [OpenAI OpenAPI spec](https://github.com/openai/openai-openapi)
 - Current features:
-  - [x] Audio
+  - [x] Audio (Whisper/TTS)
   - [x] Chat
   - [x] Completions (Legacy)
   - [x] Edits (Deprecated)

--- a/async-openai/src/audio.rs
+++ b/async-openai/src/audio.rs
@@ -1,9 +1,11 @@
+use bytes::Bytes;
+
 use crate::{
     config::Config,
     error::OpenAIError,
     types::{
-        CreateTranscriptionRequest, CreateTranscriptionResponse, CreateTranslationRequest,
-        CreateTranslationResponse,
+        CreateSpeechRequest, CreateTranscriptionRequest, CreateTranscriptionResponse,
+        CreateTranslationRequest, CreateTranslationResponse,
     },
     Client,
 };
@@ -35,5 +37,9 @@ impl<'c, C: Config> Audio<'c, C> {
         request: CreateTranslationRequest,
     ) -> Result<CreateTranslationResponse, OpenAIError> {
         self.client.post_form("/audio/translations", request).await
+    }
+
+    pub async fn speech(&self, request: CreateSpeechRequest) -> Result<Bytes, OpenAIError> {
+        self.client.post_raw("/audio/speech", request).await
     }
 }

--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -1279,6 +1279,9 @@ pub struct CreateSpeechRequest {
     /// ID of the model to use. Only `tts-1` and `tts-1-hd` are currently available.
     pub model: String,
 
+    /// The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`.
+    pub voice: String,
+
     /// The format to audio in. Supported formats are mp3, opus, aac, and flac.
     pub response_format: Option<SpeechResponseFormat>,
 

--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -1235,6 +1235,20 @@ pub enum SpeechResponseFormat {
     Flac,
 }
 
+#[derive(Debug, Serialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum Voice {
+    Alloy,
+    Echo,
+    Fable,
+    Onyx,
+    Nova,
+    Shimmer,
+    Other(String),
+}
+
 #[derive(Clone, Default, Debug, Builder, PartialEq)]
 #[builder(name = "CreateTranscriptionRequestArgs")]
 #[builder(pattern = "mutable")]
@@ -1266,10 +1280,10 @@ pub struct CreateTranscriptionResponse {
     pub text: String,
 }
 
-#[derive(Clone, Default, Debug, Builder, PartialEq, Serialize)]
+#[derive(Clone, Debug, Builder, PartialEq, Serialize)]
 #[builder(name = "CreateSpeechRequestArgs")]
 #[builder(pattern = "mutable")]
-#[builder(setter(into, strip_option), default)]
+#[builder(setter(into, strip_option))]
 #[builder(derive(Debug))]
 #[builder(build_fn(error = "OpenAIError"))]
 pub struct CreateSpeechRequest {
@@ -1280,7 +1294,7 @@ pub struct CreateSpeechRequest {
     pub model: String,
 
     /// The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`.
-    pub voice: String,
+    pub voice: Voice,
 
     /// The format to audio in. Supported formats are mp3, opus, aac, and flac.
     pub response_format: Option<SpeechResponseFormat>,

--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -1225,6 +1225,16 @@ pub enum AudioResponseFormat {
     Vtt,
 }
 
+#[derive(Debug, Serialize, Default, Clone, Copy, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum SpeechResponseFormat {
+    #[default]
+    Mp3,
+    Opus,
+    Aac,
+    Flac,
+}
+
 #[derive(Clone, Default, Debug, Builder, PartialEq)]
 #[builder(name = "CreateTranscriptionRequestArgs")]
 #[builder(pattern = "mutable")]
@@ -1256,6 +1266,26 @@ pub struct CreateTranscriptionResponse {
     pub text: String,
 }
 
+#[derive(Clone, Default, Debug, Builder, PartialEq, Serialize)]
+#[builder(name = "CreateSpeechRequestArgs")]
+#[builder(pattern = "mutable")]
+#[builder(setter(into, strip_option), default)]
+#[builder(derive(Debug))]
+#[builder(build_fn(error = "OpenAIError"))]
+pub struct CreateSpeechRequest {
+    /// The text to generate audio for. The maximum length is 4096 characters.
+    pub input: String,
+
+    /// ID of the model to use. Only `tts-1` and `tts-1-hd` are currently available.
+    pub model: String,
+
+    /// The format to audio in. Supported formats are mp3, opus, aac, and flac.
+    pub response_format: Option<SpeechResponseFormat>,
+
+    /// The speed of the generated audio. Select a value from 0.25 to 4.0. 1.0 is the default.
+    pub speed: Option<f32>, // default: 1.0
+}
+
 #[derive(Clone, Default, Debug, Builder, PartialEq)]
 #[builder(name = "CreateTranslationRequestArgs")]
 #[builder(pattern = "mutable")]
@@ -1281,5 +1311,10 @@ pub struct CreateTranslationRequest {
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
 pub struct CreateTranslationResponse {
+    pub text: String,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
+pub struct CreateSpeechResponse {
     pub text: String,
 }

--- a/examples/audio-speech/.gitignore
+++ b/examples/audio-speech/.gitignore
@@ -1,0 +1,1 @@
+audio.mp3

--- a/examples/audio-speech/Cargo.toml
+++ b/examples/audio-speech/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "audio-speech"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+async-openai = {path = "../../async-openai"}
+tokio = { version = "1.25.0", features = ["full"] }

--- a/examples/audio-speech/README.md
+++ b/examples/audio-speech/README.md
@@ -1,0 +1,3 @@
+### Output (as an mp3 file)
+
+> Today is a wonderful day to build something people love!

--- a/examples/audio-speech/src/main.rs
+++ b/examples/audio-speech/src/main.rs
@@ -1,0 +1,19 @@
+use async_openai::{types::CreateSpeechRequestArgs, Client};
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let client = Client::new();
+
+    let request = CreateSpeechRequestArgs::default()
+        .input("Today is a wonderful day to build something people love!".to_string())
+        .voice("alloy".to_string())
+        .model("tts-1")
+        .build()?;
+
+    let response = client.audio().speech(request).await?;
+
+    std::fs::write("audio.mp3", response)?;
+
+    Ok(())
+}

--- a/examples/audio-speech/src/main.rs
+++ b/examples/audio-speech/src/main.rs
@@ -1,4 +1,7 @@
-use async_openai::{types::CreateSpeechRequestArgs, Client};
+use async_openai::{
+    types::{CreateSpeechRequestArgs, Voice},
+    Client,
+};
 use std::error::Error;
 
 #[tokio::main]
@@ -7,7 +10,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let request = CreateSpeechRequestArgs::default()
         .input("Today is a wonderful day to build something people love!".to_string())
-        .voice("alloy".to_string())
+        .voice(Voice::Alloy)
         .model("tts-1")
         .build()?;
 


### PR DESCRIPTION
- Added a `post_raw` and `execute_raw` internal functions, since we don't want to JSON-decode the response body for the speech endpoints (which return raw audio). Modified the `execute` function to wrap around `execute_raw`.
- Added basic support for the TTS api

Note that the struct corresponding to the `response_format` parameter was named `SpeechResponseFormat` instead of `AudioResponseFormat`, since the later already existed for defining whisper response formats.

I'd love to add an enum for voices as well (with an Other wildcard and marked as non-exhaustive), but refrained since the library's pattern seems to be deferring to strings (same case as model IDs all across).