### PR TITLE
Make Run.expires_at optional

### DIFF
--- a/async-openai/src/types/assistants/run.rs
+++ b/async-openai/src/types/assistants/run.rs
@@ -32,7 +32,7 @@ pub struct RunObject {
     pub last_error: Option<LastError>,
 
     /// The Unix timestamp (in seconds) for when the run will expire.
-    pub expires_at: i32,
+    pub expires_at: Option<i32>,
     ///  The Unix timestamp (in seconds) for when the run was started.
     pub started_at: Option<i32>,
     /// The Unix timestamp (in seconds) for when the run was cancelled.


### PR DESCRIPTION
Sometimes Run retreivals fail with message that it couldn't convert null to i32. Looks like expires_at is actually optional, see example in https://platform.openai.com/docs/api-reference/runs

Change its type from i32 to Optional<i32>. The problem was resolved after this change.