### PR TITLE
Rename tools_outputs to tool_outputs

### DIFF
--- a/async-openai/src/types/assistants/run.rs
+++ b/async-openai/src/types/assistants/run.rs
@@ -147,7 +147,7 @@ pub struct ListRunsResponse {
 #[derive(Clone, Serialize, Default, Debug, Deserialize, PartialEq)]
 pub struct SubmitToolOutputsRunRequest {
     /// A list of tools for which the outputs are being submitted.
-    pub tools_outputs: Vec<ToolsOutputs>,
+    pub tool_outputs: Vec<ToolsOutputs>,
 }
 
 #[derive(Clone, Serialize, Default, Debug, Deserialize, Builder, PartialEq)]


### PR DESCRIPTION
Field SubmitToolOutputsRunRequest.tools_outputs has a typo. It should be be called tool_outputs instead.
This PR renames it to tool_outputs and fixes deserialization.