### PR TITLE
FIX: finetuningjob deserialize crash

### DIFF
--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -836,7 +836,8 @@ pub struct Hyperparameters {
     ///
     /// "auto" decides the optimal number of epochs based on the size of the dataset.
     /// If setting the number manually, we support any number between 1 and 50 epochs.
-    pub n_epochs: NEpochs,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub n_epochs: Option<NEpochs>,
 }
 
 #[derive(Debug, Serialize, Clone, Default, Builder, PartialEq)]


### PR DESCRIPTION
 let job = open_ai_client
            .fine_tuning()
            .create(fine_tune_request)
            .await?;
FineTuningJob struct is like:  
{
  "object": "fine_tuning.job",
  "id": "ftjob xxx",
  "model": "gpt-3.5-turbo-0613",
  "created_at": 1700626516,
  "finished_at": null,
  "fine_tuned_model": null,
  "organization_id": "org-zxxx",
  "result_files": [],
  "status": "validating_files",
  "validation_file": null,
  "training_file": "file-xxx",
  "hyperparameters": {
    "batch_size": "auto",
    "learning_rate_multiplier": "auto"
  },
  "trained_tokens": null,
  "error": null
}
have not n_epochs variable ,cause deserialize exception.