### PR TITLE
Fix: post_form to be Sendable

### DIFF
--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -235,7 +235,7 @@ impl<C: Config> Client<C> {
                 .post(self.config.url(path))
                 .query(&self.config.query())
                 .headers(self.config.headers())
-                .multipart(async_convert::TryInto::try_into(form.clone()).await?)
+                .multipart(async_convert::TryFrom::try_from(form.clone()).await?)
                 .build()?)
         };
 

--- a/async-openai/tests/whisper.rs
+++ b/async-openai/tests/whisper.rs
@@ -30,7 +30,7 @@ async fn transcribe_sendable_test() {
 }
 
 #[tokio::test]
-async fn translate() {
+async fn translate_test() {
     let client = Client::new();
 
     let request = CreateTranslationRequestArgs::default().build().unwrap();

--- a/async-openai/tests/whisper.rs
+++ b/async-openai/tests/whisper.rs
@@ -1,0 +1,57 @@
+use async_openai::types::CreateTranslationRequestArgs;
+use async_openai::{types::CreateTranscriptionRequestArgs, Client};
+use tokio_test::assert_err;
+
+#[tokio::test]
+async fn transcribe_test() {
+    let client = Client::new();
+
+    let request = CreateTranscriptionRequestArgs::default().build().unwrap();
+
+    let response = client.audio().transcribe(request).await;
+
+    assert_err!(response); // FileReadError("cannot extract file name from ")
+}
+
+#[tokio::test]
+async fn transcribe_sendable_test() {
+    let client = Client::new();
+
+    // https://github.com/64bit/async-openai/issues/140
+    let transcribe = tokio::spawn(async move {
+        let request = CreateTranscriptionRequestArgs::default().build().unwrap();
+
+        client.audio().transcribe(request).await
+    });
+
+    let response = transcribe.await.unwrap();
+
+    assert_err!(response); // FileReadError("cannot extract file name from ")
+}
+
+#[tokio::test]
+async fn translate() {
+    let client = Client::new();
+
+    let request = CreateTranslationRequestArgs::default().build().unwrap();
+
+    let response = client.audio().translate(request).await;
+
+    assert_err!(response); // FileReadError("cannot extract file name from ")
+}
+
+#[tokio::test]
+async fn translate_sendable_test() {
+    let client = Client::new();
+
+    // https://github.com/64bit/async-openai/issues/140
+    let translate = tokio::spawn(async move {
+        let request = CreateTranslationRequestArgs::default().build().unwrap();
+
+        client.audio().translate(request).await
+    });
+
+    let response = translate.await.unwrap();
+
+    assert_err!(response); // FileReadError("cannot extract file name from ")
+}


### PR DESCRIPTION
this pr may resolve #140.

Before the fix, call audio transcription resulted in the following error:

```rust
#[tokio::test]
async fn multipart_form_test() {
    let client = Client::new();

    // https://github.com/64bit/async-openai/issues/140
    let transcribe_task = tokio::spawn(async move { 
        transcribe(client).await 
    });
    
    let result = tokio::join!(transcribe_task);
    println!("transcribe: {:?}", result.0);
}

async fn transcribe(client: Client<OpenAIConfig>) -> Result<String, OpenAIError> {
    // Credits and Source for audio: https://www.youtube.com/watch?v=oQnDVqGIv4s
    let request = CreateTranscriptionRequestArgs::default()
        .file(
            "../examples/audio-transcribe/audio/A Message From Sir David Attenborough A Perfect Planet BBC Earth_320kbps.mp3"
        )
        .model("whisper-1")
        .response_format(async_openai::types::AudioResponseFormat::VerboseJson)
        .build()?;

    let response = client.audio().transcribe(request).await?;

    println!("{:?}", response);

    Ok(response.text)
}
```

```
error: future cannot be sent between threads safely
   --> async-openai/tests/multipart_form.rs:16:40
    |
16  |     let transcribe_task = tokio::spawn(async move { transcribe(transcribe_client).await });
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `Send` is not implemented for `dyn Future<Output = Result<reqwest::async_impl::multipart::Form, OpenAIError>>`
note: required by a bound in `tokio::spawn`
   --> /Users/yuuyakt/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/task/spawn.rs:166:21
```


this example is another branch.

https://github.com/katya4oyu/async-openai/blob/whisper/async-openai/tests/multipart_form.rs
