### PR TITLE
Fix: Make ChatCompletionToolChoiceOption enum variants lowercase

### DIFF
--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -1374,6 +1374,7 @@ pub struct ChatCompletionNamedToolChoice {
 
 /// `none` is the default when no functions are present. `auto` is the default if functions are present.
 #[derive(Clone, Serialize, Default, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
 pub enum ChatCompletionToolChoiceOption {
     #[default]
     None,


### PR DESCRIPTION
Setting this to `auto` was causing my requests to fail because of malformed values in the `tool_choice` filed.

I think the OpenAI API is expecting these values to be lowercase but "Auto" will be capitalised.
https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice

I only tested this with the "Auto" value. But I assume this should also work for the other variants  