### PR TITLE
Support vLLM-style emulation of OpenAI endpoint.

### DIFF
--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf, pin::Pin};
 use bytes::Bytes;
 use derive_builder::Builder;
 use futures::Stream;
-use reqwest::{Body};
+use reqwest::Body;
 use serde::{Deserialize, Serialize};
 
 use crate::error::OpenAIError;
@@ -1594,14 +1594,14 @@ pub struct CreateChatCompletionStreamResponse {
     pub choices: Vec<ChatCompletionResponseStreamMessage>,
 
     /// The Unix timestamp (in seconds) of when the chat completion was created. Each chunk has the same timestamp.
-    pub created: u32,
+    pub created: Option<u32>,
     /// The model to generate the completion.
     pub model: String,
     /// This fingerprint represents the backend configuration that the model runs with.
     /// Can be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.
     pub system_fingerprint: Option<String>,
     /// The object type, which is always `chat.completion.chunk`.
-    pub object: String,
+    pub object: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq)]

--- a/async-openai/src/types/types.rs
+++ b/async-openai/src/types/types.rs
@@ -215,7 +215,7 @@ pub struct CreateCompletionResponse {
     pub system_fingerprint: Option<String>,
 
     /// The object type, which is always "text_completion"
-    pub object: String,
+    pub object: Option<String>,
     pub usage: Option<CompletionUsage>,
 }
 


### PR DESCRIPTION
```
my_rust_project-1   | [2023-12-07T23:13:30Z ERROR async_openai::error] failed deserialization of: {"id": "cmpl-2fe481188f2447dca57fd0be25f8fafc", "model": "TheBloke/zephyr-7B-alpha-AWQ", "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": null}]}
vllm-nv-1        | INFO 12-07 23:13:31 llm_engine.py:636] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 1.1%, CPU KV cache usage: 0.0%
my_rust_project-1   | [2023-12-07T23:13:31Z ERROR async_openai::error] failed deserialization of: {"id": "cmpl-2fe481188f2447dca57fd0be25f8fafc", "created": 76644, "model": "TheBloke/zephyr-7B-alpha-AWQ", "choices": [{"index": 0, "delta": {"content": "Acc"}, "finish_reason": null}]}
```

As you can see from the log, the `created` timestamp is not always present, and `object` never is. Now it's compatible with both.