### PR TITLE
Optional model in ModifyAssistantRequest

### DIFF
--- a/async-openai/src/types/assistant.rs
+++ b/async-openai/src/types/assistant.rs
@@ -94,7 +94,8 @@ pub struct CreateAssistantRequest {
 #[builder(derive(Debug))]
 #[builder(build_fn(error = "OpenAIError"))]
 pub struct ModifyAssistantRequest {
-    pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,


### PR DESCRIPTION
@64bit 
All fields (including model) are optional in OpenAI API.