### PR TITLE
Add support for streaming TTS response from the /audio/speech endpoint

### DIFF
--- a/async-openai/src/audio.rs
+++ b/async-openai/src/audio.rs
@@ -59,6 +59,7 @@ impl<'c, C: Config> Audio<'c, C> {
         let stream = Box::pin(self.client.post_raw_stream("/audio/speech", request)
             .await?
             .map(|stream_item| stream_item.map(|b| CreateSpeechResponse { bytes: b })));
+
         Ok(stream)
     }
 }

--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -359,6 +359,7 @@ impl<C: Config> Client<C> {
             .map_err(OpenAIError::Reqwest)?;
 
         let stream = response.bytes_stream().map(|item| item.map_err(OpenAIError::Reqwest));
+
         Ok(Box::pin(stream))
     }
 

--- a/async-openai/src/types/audio.rs
+++ b/async-openai/src/types/audio.rs
@@ -1,6 +1,8 @@
 use bytes::Bytes;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
+use futures::Stream;
+use std::{pin::Pin};
 
 use super::InputSource;
 use crate::error::OpenAIError;
@@ -145,3 +147,6 @@ pub struct CreateTranslationResponse {
 pub struct CreateSpeechResponse {
     pub bytes: Bytes,
 }
+
+pub type SpeechResponseStream =
+    Pin<Box<dyn Stream<Item = Result<CreateSpeechResponse, OpenAIError>> + Send>>;

--- a/examples/audio-speech-stream/Cargo.toml
+++ b/examples/audio-speech-stream/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "audio-speech-stream"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+async-openai = {path = "../../async-openai"}
+tokio = { version = "1.25.0", features = ["full"] }
+futures = "0.3.26"
+bytes = "1.5.0"

--- a/examples/audio-speech-stream/README.md
+++ b/examples/audio-speech-stream/README.md
@@ -1,0 +1,3 @@
+### Output (as an mp3 file)
+
+> Today is a wonderful day to build something people love!

--- a/examples/audio-speech-stream/README.md
+++ b/examples/audio-speech-stream/README.md
@@ -1,3 +1,5 @@
 ### Output (as an mp3 file)
 
-> Today is a wonderful day to build something people love!
+> Today is a wonderful day to stream something people love!
+
+The data will be written to disk in a streaming fashion.

--- a/examples/audio-speech-stream/src/main.rs
+++ b/examples/audio-speech-stream/src/main.rs
@@ -1,0 +1,45 @@
+use async_openai::{
+    types::{CreateSpeechRequestArgs, SpeechResponseFormat, SpeechModel, Voice},
+    Client,
+};
+use std::error::Error;
+use std::fs::File;
+use std::io::Write;
+use futures::{future, StreamExt};
+use bytes::{Buf, Bytes, BytesMut, BufMut};
+use bytes::buf::Reader;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let client = Client::new();
+
+    let request = CreateSpeechRequestArgs::default()
+        .input("Today is a wonderful day to stream something people love!")
+        .voice(Voice::Alloy)
+        .model(SpeechModel::Tts1)
+        .response_format(SpeechResponseFormat::Mp3)
+        .build()?;
+
+    let mut stream = client.audio().speech_stream(request).await?;
+
+    let mut file = File::create("./speech_stream.mp3")?; 
+    
+    stream.for_each(|item| {
+        match item {
+            Ok(response) => {
+                let res_size = file.write(&response.bytes);
+                match res_size {
+                    Ok(size) => println!("Wrote {size} bytes to disk"),
+                    Err(err) => println!("Could not write to disk: {err}")
+                }
+            },
+            Err(err) => {
+                println!("error: {err}");
+            }
+        }
+        future::ready(())
+    }).await; 
+
+    Ok(())
+}
+


### PR DESCRIPTION
**Problem**

OpenAI supports streaming for its /audio/speech endpoint but this functionality is not available in `async-openai`.

**Solution**

* Add support for response streaming following the existing coding patterns from the codebase.

A couple of decisions were taken:
- Add a `post_raw_stream` functionality in the client as using the existing SSE pattern would not work (the EventSource library decodes its data into a String and there is no byte mode from what I could tell).
- Do not introduce new specific types for the input and output structures, reusing the equivalent non stream type versions. This follows the existing convention from what I could tell.
- Introduce a simple example streaming to disk the audio output. Another example could have been to stream to the audio output but this would have needed the introduction of a playback library as well as a streaming audio decoder, which feels out of scope of this library. 


Related to #177.