### PR TITLE
Borrow instead of moving CreateChatCompletionRequest

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -40,9 +40,9 @@ tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.7", features = ["codec", "io-util"] }
 tracing = "0.1.37"
 derive_builder = "0.12.0"
-async-convert = "1.0.0"
 secrecy = { version = "0.8.0", features=["serde"] }
 bytes = "1.5.0"
+async-trait = "0.1.52"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/async-openai/src/assistant_files.rs
+++ b/async-openai/src/assistant_files.rs
@@ -27,7 +27,7 @@ impl<'c, C: Config> AssistantFiles<'c, C> {
     /// Create an assistant file by attaching a [File](https://platform.openai.com/docs/api-reference/files) to an [assistant](https://platform.openai.com/docs/api-reference/assistants).
     pub async fn create(
         &self,
-        request: CreateAssistantFileRequest,
+        request: &CreateAssistantFileRequest,
     ) -> Result<AssistantFileObject, OpenAIError> {
         self.client
             .post(&format!("/assistants/{}/files", self.assistant_id), request)

--- a/async-openai/src/assistants.rs
+++ b/async-openai/src/assistants.rs
@@ -30,7 +30,7 @@ impl<'c, C: Config> Assistants<'c, C> {
     /// Create an assistant with a model and instructions.
     pub async fn create(
         &self,
-        request: CreateAssistantRequest,
+        request: &CreateAssistantRequest,
     ) -> Result<AssistantObject, OpenAIError> {
         self.client.post("/assistants", request).await
     }
@@ -46,7 +46,7 @@ impl<'c, C: Config> Assistants<'c, C> {
     pub async fn update(
         &self,
         assistant_id: &str,
-        request: ModifyAssistantRequest,
+        request: &ModifyAssistantRequest,
     ) -> Result<AssistantObject, OpenAIError> {
         self.client
             .post(&format!("/assistants/{assistant_id}"), request)

--- a/async-openai/src/async_convert.rs
+++ b/async-openai/src/async_convert.rs
@@ -38,28 +38,6 @@
 //! [`async_trait`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html)
 //! crate. This is an experiment, but we'll likely want to extend `async-std`
 //! with this at some point too.
-//!
-//! # Examples
-//!
-//! ```
-//! use async_convert::{async_trait, TryFrom};
-//!
-//! struct GreaterThanZero(i32);
-//!
-//! #[async_trait]
-//! impl TryFrom<i32> for GreaterThanZero {
-//!     type Error = &'static str;
-//!
-//!     async fn try_from(value: i32) -> Result<Self, Self::Error> {
-//!         // pretend we're actually doing async IO here instead.
-//!         if value <= 0 {
-//!             Err("GreaterThanZero only accepts value superior than zero!")
-//!         } else {
-//!             Ok(GreaterThanZero(value))
-//!         }
-//!     }
-//! }
-//! ```
 
 #![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
 #![deny(missing_debug_implementations, nonstandard_style)]
@@ -93,7 +71,9 @@ pub trait TryFrom<T>: Sized {
     type Error;
 
     /// Performs the conversion.
-    async fn try_from(value: T) -> Result<Self, Self::Error>;
+    async fn try_from(value: T) -> Result<Self, Self::Error>
+    where
+        T: 'async_trait;
 }
 
 /// An attempted conversion that consumes `self`, which may or may not be

--- a/async-openai/src/async_convert.rs
+++ b/async-openai/src/async_convert.rs
@@ -1,0 +1,133 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Yoshua Wuyts
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//! Async `TryFrom`/`TryInto` traits.
+//!
+//! # Why
+//!
+//! In async-std we created async versions of `FromStream`, `IntoStream`, and
+//! `Iterator::collect`. These traits represent conversions from one type to
+//! another. But the canonical way of performing this conversion is through the
+//! `TryFrom` and `TryInto` traits.
+//!
+//! For example when deserializing some `MyBody` from a `Request`, you will want
+//! to declare a `TryFrom<Request> for MyBody` which consumes the bytes in the
+//! request and tries to create the body. This operation is fallible, and when
+//! writing async code also needs to be async.
+//!
+//! This crate provides traits for that, through the
+//! [`async_trait`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html)
+//! crate. This is an experiment, but we'll likely want to extend `async-std`
+//! with this at some point too.
+//!
+//! # Examples
+//!
+//! ```
+//! use async_convert::{async_trait, TryFrom};
+//!
+//! struct GreaterThanZero(i32);
+//!
+//! #[async_trait]
+//! impl TryFrom<i32> for GreaterThanZero {
+//!     type Error = &'static str;
+//!
+//!     async fn try_from(value: i32) -> Result<Self, Self::Error> {
+//!         // pretend we're actually doing async IO here instead.
+//!         if value <= 0 {
+//!             Err("GreaterThanZero only accepts value superior than zero!")
+//!         } else {
+//!             Ok(GreaterThanZero(value))
+//!         }
+//!     }
+//! }
+//! ```
+
+#![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
+#![deny(missing_debug_implementations, nonstandard_style)]
+#![warn(missing_docs, rustdoc::missing_doc_code_examples, unreachable_pub)]
+
+pub use async_trait::async_trait;
+
+/// A shared prelude.
+pub mod prelude {
+    pub use super::TryFrom as _;
+    pub use super::TryInto as _;
+}
+
+/// Simple and safe type conversions that may fail in a controlled
+/// way under some circumstances. It is the reciprocal of [`TryInto`].
+///
+/// This is useful when you are doing a type conversion that may
+/// trivially succeed but may also need special handling.
+/// For example, there is no way to convert an [`i64`] into an [`i32`]
+/// using the [`From`] trait, because an [`i64`] may contain a value
+/// that an [`i32`] cannot represent and so the conversion would lose data.
+/// This might be handled by truncating the [`i64`] to an [`i32`] (essentially
+/// giving the [`i64`]'s value modulo [`i32::MAX`]) or by simply returning
+/// [`i32::MAX`], or by some other method.  The [`From`] trait is intended
+/// for perfect conversions, so the `TryFrom` trait informs the
+/// programmer when a type conversion could go bad and lets them
+/// decide how to handle it.
+#[async_trait]
+pub trait TryFrom<T>: Sized {
+    /// The type returned in the event of a conversion error.
+    type Error;
+
+    /// Performs the conversion.
+    async fn try_from(value: T) -> Result<Self, Self::Error>;
+}
+
+/// An attempted conversion that consumes `self`, which may or may not be
+/// expensive.
+///
+/// Library authors should usually not directly implement this trait,
+/// but should prefer implementing the [`TryFrom`] trait, which offers
+/// greater flexibility and provides an equivalent `TryInto`
+/// implementation for free, thanks to a blanket implementation in the
+/// standard library. For more information on this, see the
+/// documentation for [`Into`].
+///
+/// # Implementing `TryInto`
+///
+/// This suffers the same restrictions and reasoning as implementing
+/// [`Into`], see there for details.
+#[async_trait(?Send)]
+pub trait TryInto<T>: Sized {
+    /// The type returned in the event of a conversion error.
+    type Error;
+
+    /// Performs the conversion.
+    async fn try_into(self) -> Result<T, Self::Error>;
+}
+
+// TryFrom implies TryInto
+#[async_trait(?Send)]
+impl<T, U> TryInto<U> for T
+where
+    U: TryFrom<T>,
+{
+    type Error = U::Error;
+
+    async fn try_into(self) -> Result<U, U::Error> {
+        U::try_from(self).await
+    }
+}

--- a/async-openai/src/audio.rs
+++ b/async-openai/src/audio.rs
@@ -22,7 +22,7 @@ impl<'c, C: Config> Audio<'c, C> {
     /// Transcribes audio into the input language.
     pub async fn transcribe(
         &self,
-        request: CreateTranscriptionRequest,
+        request: &CreateTranscriptionRequest,
     ) -> Result<CreateTranscriptionResponse, OpenAIError> {
         self.client
             .post_form("/audio/transcriptions", request)
@@ -32,7 +32,7 @@ impl<'c, C: Config> Audio<'c, C> {
     /// Translates audio into into English.
     pub async fn translate(
         &self,
-        request: CreateTranslationRequest,
+        request: &CreateTranslationRequest,
     ) -> Result<CreateTranslationResponse, OpenAIError> {
         self.client.post_form("/audio/translations", request).await
     }
@@ -40,7 +40,7 @@ impl<'c, C: Config> Audio<'c, C> {
     /// Generates audio from the input text.
     pub async fn speech(
         &self,
-        request: CreateSpeechRequest,
+        request: &CreateSpeechRequest,
     ) -> Result<CreateSpeechResponse, OpenAIError> {
         let bytes = self.client.post_raw("/audio/speech", request).await?;
 

--- a/async-openai/src/chat.rs
+++ b/async-openai/src/chat.rs
@@ -22,7 +22,7 @@ impl<'c, C: Config> Chat<'c, C> {
     /// Creates a model response for the given chat conversation.
     pub async fn create(
         &self,
-        request: CreateChatCompletionRequest,
+        request: &CreateChatCompletionRequest,
     ) -> Result<CreateChatCompletionResponse, OpenAIError> {
         if request.stream.is_some() && request.stream.unwrap() {
             return Err(OpenAIError::InvalidArgument(

--- a/async-openai/src/chat.rs
+++ b/async-openai/src/chat.rs
@@ -39,7 +39,7 @@ impl<'c, C: Config> Chat<'c, C> {
     /// [ChatCompletionResponseStream] is a parsed SSE stream until a \[DONE\] is received from server.
     pub async fn create_stream(
         &self,
-        mut request: CreateChatCompletionRequest,
+        mut request: &CreateChatCompletionRequest,
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
         if request.stream.is_some() && !request.stream.unwrap() {
             return Err(OpenAIError::InvalidArgument(

--- a/async-openai/src/chat.rs
+++ b/async-openai/src/chat.rs
@@ -39,7 +39,7 @@ impl<'c, C: Config> Chat<'c, C> {
     /// [ChatCompletionResponseStream] is a parsed SSE stream until a \[DONE\] is received from server.
     pub async fn create_stream(
         &self,
-        mut request: &CreateChatCompletionRequest,
+        request: &mut CreateChatCompletionRequest,
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
         if request.stream.is_some() && !request.stream.unwrap() {
             return Err(OpenAIError::InvalidArgument(

--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -6,6 +6,7 @@ use reqwest_eventsource::{Event, EventSource, RequestBuilderExt};
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
+    async_convert,
     config::{Config, OpenAIConfig},
     edit::Edits,
     error::{map_deserialization_error, OpenAIError, WrappedError},

--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -186,7 +186,7 @@ impl<C: Config> Client<C> {
     }
 
     /// Make a POST request to {path} and return the response body
-    pub(crate) async fn post_raw<I>(&self, path: &str, request: I) -> Result<Bytes, OpenAIError>
+    pub(crate) async fn post_raw<I>(&self, path: &str, request: &I) -> Result<Bytes, OpenAIError>
     where
         I: Serialize,
     {
@@ -204,7 +204,7 @@ impl<C: Config> Client<C> {
     }
 
     /// Make a POST request to {path} and deserialize the response body
-    pub(crate) async fn post<I, O>(&self, path: &str, request: I) -> Result<O, OpenAIError>
+    pub(crate) async fn post<I, O>(&self, path: &str, request: &I) -> Result<O, OpenAIError>
     where
         I: Serialize,
         O: DeserializeOwned,
@@ -215,7 +215,7 @@ impl<C: Config> Client<C> {
                 .post(self.config.url(path))
                 .query(&self.config.query())
                 .headers(self.config.headers())
-                .json(&request)
+                .json(request)
                 .build()?)
         };
 
@@ -321,7 +321,7 @@ impl<C: Config> Client<C> {
     pub(crate) async fn post_stream<I, O>(
         &self,
         path: &str,
-        request: I,
+        request: &I,
     ) -> Pin<Box<dyn Stream<Item = Result<O, OpenAIError>> + Send>>
     where
         I: Serialize,

--- a/async-openai/src/completion.rs
+++ b/async-openai/src/completion.rs
@@ -23,7 +23,7 @@ impl<'c, C: Config> Completions<'c, C> {
     /// Creates a completion for the provided prompt and parameters
     pub async fn create(
         &self,
-        request: CreateCompletionRequest,
+        request: &CreateCompletionRequest,
     ) -> Result<CreateCompletionResponse, OpenAIError> {
         if request.stream.is_some() && request.stream.unwrap() {
             return Err(OpenAIError::InvalidArgument(
@@ -42,7 +42,7 @@ impl<'c, C: Config> Completions<'c, C> {
     /// [CompletionResponseStream] is a parsed SSE stream until a \[DONE\] is received from server.
     pub async fn create_stream(
         &self,
-        mut request: CreateCompletionRequest,
+        mut request: &CreateCompletionRequest,
     ) -> Result<CompletionResponseStream, OpenAIError> {
         if request.stream.is_some() && !request.stream.unwrap() {
             return Err(OpenAIError::InvalidArgument(

--- a/async-openai/src/completion.rs
+++ b/async-openai/src/completion.rs
@@ -42,7 +42,7 @@ impl<'c, C: Config> Completions<'c, C> {
     /// [CompletionResponseStream] is a parsed SSE stream until a \[DONE\] is received from server.
     pub async fn create_stream(
         &self,
-        mut request: &CreateCompletionRequest,
+        request: &mut CreateCompletionRequest,
     ) -> Result<CompletionResponseStream, OpenAIError> {
         if request.stream.is_some() && !request.stream.unwrap() {
             return Err(OpenAIError::InvalidArgument(

--- a/async-openai/src/edit.rs
+++ b/async-openai/src/edit.rs
@@ -19,7 +19,7 @@ impl<'c, C: Config> Edits<'c, C> {
     /// Creates a new edit for the provided input, instruction, and parameters
     pub async fn create(
         &self,
-        request: CreateEditRequest,
+        request: &CreateEditRequest,
     ) -> Result<CreateEditResponse, OpenAIError> {
         self.client.post("/edits", request).await
     }

--- a/async-openai/src/embedding.rs
+++ b/async-openai/src/embedding.rs
@@ -29,8 +29,8 @@ impl<'c, C: Config> Embeddings<'c, C> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{types::CreateEmbeddingRequestArgs, Client};
     use crate::types::{CreateEmbeddingResponse, Embedding};
+    use crate::{types::CreateEmbeddingRequestArgs, Client};
 
     #[tokio::test]
     async fn test_embedding_string() {
@@ -122,7 +122,7 @@ mod tests {
 
         assert!(response.is_ok());
 
-        let CreateEmbeddingResponse { mut data, ..} = response.unwrap();
+        let CreateEmbeddingResponse { mut data, .. } = response.unwrap();
         assert_eq!(data.len(), 1);
         let Embedding { embedding, .. } = data.pop().unwrap();
         assert_eq!(embedding.len(), dimensions as usize);

--- a/async-openai/src/embedding.rs
+++ b/async-openai/src/embedding.rs
@@ -42,7 +42,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let response = client.embeddings().create(request).await;
+        let response = client.embeddings().create(&request).await;
 
         assert!(response.is_ok());
     }
@@ -57,7 +57,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let response = client.embeddings().create(request).await;
+        let response = client.embeddings().create(&request).await;
 
         assert!(response.is_ok());
     }
@@ -72,7 +72,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let response = client.embeddings().create(request).await;
+        let response = client.embeddings().create(&request).await;
 
         assert!(response.is_ok());
     }
@@ -87,7 +87,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let response = client.embeddings().create(request).await;
+        let response = client.embeddings().create(&request).await;
 
         assert!(response.is_ok());
     }
@@ -102,7 +102,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let response = client.embeddings().create(request).await;
+        let response = client.embeddings().create(&request).await;
 
         assert!(response.is_ok());
     }
@@ -118,7 +118,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let response = client.embeddings().create(request).await;
+        let response = client.embeddings().create(&request).await;
 
         assert!(response.is_ok());
 

--- a/async-openai/src/embedding.rs
+++ b/async-openai/src/embedding.rs
@@ -21,7 +21,7 @@ impl<'c, C: Config> Embeddings<'c, C> {
     /// Creates an embedding vector representing the input text.
     pub async fn create(
         &self,
-        request: CreateEmbeddingRequest,
+        request: &CreateEmbeddingRequest,
     ) -> Result<CreateEmbeddingResponse, OpenAIError> {
         self.client.post("/embeddings", request).await
     }

--- a/async-openai/src/file.rs
+++ b/async-openai/src/file.rs
@@ -76,7 +76,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let openai_file = client.files().create(request).await.unwrap();
+        let openai_file = client.files().create(&request).await.unwrap();
 
         assert_eq!(openai_file.bytes, 135);
         assert_eq!(openai_file.filename, "test.jsonl");

--- a/async-openai/src/file.rs
+++ b/async-openai/src/file.rs
@@ -22,7 +22,7 @@ impl<'c, C: Config> Files<'c, C> {
     /// The size of individual files can be a maximum of 512 MB or 2 million tokens for Assistants. See the [Assistants Tools guide](https://platform.openai.com/docs/assistants/tools) to learn more about the types of files supported. The Fine-tuning API only supports `.jsonl` files.
     ///
     /// Please [contact us](https://help.openai.com/) if you need to increase these storage limits.
-    pub async fn create(&self, request: CreateFileRequest) -> Result<OpenAIFile, OpenAIError> {
+    pub async fn create(&self, request: &CreateFileRequest) -> Result<OpenAIFile, OpenAIError> {
         self.client.post_form("/files", request).await
     }
 

--- a/async-openai/src/fine_tune.rs
+++ b/async-openai/src/fine_tune.rs
@@ -25,7 +25,7 @@ impl<'c, C: Config> FineTunes<'c, C> {
     /// Response includes details of the enqueued job including job status and the name of the fine-tuned models once complete.
     ///
     /// [Learn more about Fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)
-    pub async fn create(&self, request: CreateFineTuneRequest) -> Result<FineTune, OpenAIError> {
+    pub async fn create(&self, request: &CreateFineTuneRequest) -> Result<FineTune, OpenAIError> {
         self.client.post("/fine-tunes", request).await
     }
 
@@ -46,7 +46,7 @@ impl<'c, C: Config> FineTunes<'c, C> {
     /// Immediately cancel a fine-tune job.
     pub async fn cancel(&self, fine_tune_id: &str) -> Result<FineTune, OpenAIError> {
         self.client
-            .post(format!("/fine-tunes/{fine_tune_id}/cancel").as_str(), ())
+            .post(format!("/fine-tunes/{fine_tune_id}/cancel").as_str(), &())
             .await
     }
 

--- a/async-openai/src/fine_tuning.rs
+++ b/async-openai/src/fine_tuning.rs
@@ -29,7 +29,7 @@ impl<'c, C: Config> FineTuning<'c, C> {
     /// [Learn more about Fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)
     pub async fn create(
         &self,
-        request: CreateFineTuningJobRequest,
+        request: &CreateFineTuningJobRequest,
     ) -> Result<FineTuningJob, OpenAIError> {
         self.client.post("/fine_tuning/jobs", request).await
     }
@@ -59,7 +59,7 @@ impl<'c, C: Config> FineTuning<'c, C> {
         self.client
             .post(
                 format!("/fine_tuning/jobs/{fine_tuning_job_id}/cancel").as_str(),
-                (),
+                &(),
             )
             .await
     }

--- a/async-openai/src/image.rs
+++ b/async-openai/src/image.rs
@@ -20,14 +20,14 @@ impl<'c, C: Config> Images<'c, C> {
     }
 
     /// Creates an image given a prompt.
-    pub async fn create(&self, request: CreateImageRequest) -> Result<ImagesResponse, OpenAIError> {
+    pub async fn create(&self, request: &CreateImageRequest) -> Result<ImagesResponse, OpenAIError> {
         self.client.post("/images/generations", request).await
     }
 
     /// Creates an edited or extended image given an original image and a prompt.
     pub async fn create_edit(
         &self,
-        request: CreateImageEditRequest,
+        request: &CreateImageEditRequest,
     ) -> Result<ImagesResponse, OpenAIError> {
         self.client.post_form("/images/edits", request).await
     }
@@ -35,7 +35,7 @@ impl<'c, C: Config> Images<'c, C> {
     /// Creates a variation of a given image.
     pub async fn create_variation(
         &self,
-        request: CreateImageVariationRequest,
+        request: &CreateImageVariationRequest,
     ) -> Result<ImagesResponse, OpenAIError> {
         self.client.post_form("/images/variations", request).await
     }

--- a/async-openai/src/image.rs
+++ b/async-openai/src/image.rs
@@ -20,7 +20,10 @@ impl<'c, C: Config> Images<'c, C> {
     }
 
     /// Creates an image given a prompt.
-    pub async fn create(&self, request: &CreateImageRequest) -> Result<ImagesResponse, OpenAIError> {
+    pub async fn create(
+        &self,
+        request: &CreateImageRequest,
+    ) -> Result<ImagesResponse, OpenAIError> {
         self.client.post("/images/generations", request).await
     }
 

--- a/async-openai/src/lib.rs
+++ b/async-openai/src/lib.rs
@@ -56,7 +56,7 @@
 //! // Create request using builder pattern
 //! // Every request struct has companion builder struct with same name + Args suffix
 //! let request = CreateCompletionRequestArgs::default()
-//!     .model("text-davinci-003")
+//!     .model("davinci-002")
 //!     .prompt("Tell me the recipe of alfredo pasta")
 //!     .max_tokens(40_u16)
 //!     .build()
@@ -65,7 +65,7 @@
 //! // Call API
 //! let response = client
 //!     .completions()      // Get the API "group" (completions, images, etc.) from the client
-//!     .create(request)    // Make the API call in that "group"
+//!     .create(&request)    // Make the API call in that "group"
 //!     .await
 //!     .unwrap();
 //!

--- a/async-openai/src/lib.rs
+++ b/async-openai/src/lib.rs
@@ -78,6 +78,7 @@
 //!
 mod assistant_files;
 mod assistants;
+mod async_convert;
 mod audio;
 mod chat;
 mod client;

--- a/async-openai/src/messages.rs
+++ b/async-openai/src/messages.rs
@@ -30,7 +30,7 @@ impl<'c, C: Config> Messages<'c, C> {
     /// Create a message.
     pub async fn create(
         &self,
-        request: CreateMessageRequest,
+        request: &CreateMessageRequest,
     ) -> Result<MessageObject, OpenAIError> {
         self.client
             .post(&format!("/threads/{}/messages", self.thread_id), request)
@@ -51,7 +51,7 @@ impl<'c, C: Config> Messages<'c, C> {
     pub async fn update(
         &self,
         message_id: &str,
-        request: ModifyMessageRequest,
+        request: &ModifyMessageRequest,
     ) -> Result<MessageObject, OpenAIError> {
         self.client
             .post(

--- a/async-openai/src/moderation.rs
+++ b/async-openai/src/moderation.rs
@@ -20,7 +20,7 @@ impl<'c, C: Config> Moderations<'c, C> {
     /// Classifies if text violates OpenAI's Content Policy
     pub async fn create(
         &self,
-        request: CreateModerationRequest,
+        request: &CreateModerationRequest,
     ) -> Result<CreateModerationResponse, OpenAIError> {
         self.client.post("/moderations", request).await
     }

--- a/async-openai/src/runs.rs
+++ b/async-openai/src/runs.rs
@@ -33,7 +33,7 @@ impl<'c, C: Config> Runs<'c, C> {
     }
 
     /// Create a run.
-    pub async fn create(&self, request: CreateRunRequest) -> Result<RunObject, OpenAIError> {
+    pub async fn create(&self, request: &CreateRunRequest) -> Result<RunObject, OpenAIError> {
         self.client
             .post(&format!("/threads/{}/runs", self.thread_id), request)
             .await
@@ -50,7 +50,7 @@ impl<'c, C: Config> Runs<'c, C> {
     pub async fn update(
         &self,
         run_id: &str,
-        request: ModifyRunRequest,
+        request: &ModifyRunRequest,
     ) -> Result<RunObject, OpenAIError> {
         self.client
             .post(
@@ -74,7 +74,7 @@ impl<'c, C: Config> Runs<'c, C> {
     pub async fn submit_tool_outputs(
         &self,
         run_id: &str,
-        request: SubmitToolOutputsRunRequest,
+        request: &SubmitToolOutputsRunRequest,
     ) -> Result<RunObject, OpenAIError> {
         self.client
             .post(
@@ -92,7 +92,7 @@ impl<'c, C: Config> Runs<'c, C> {
         self.client
             .post(
                 &format!("/threads/{}/runs/{run_id}/cancel", self.thread_id),
-                (),
+                &(),
             )
             .await
     }

--- a/async-openai/src/threads.rs
+++ b/async-openai/src/threads.rs
@@ -33,13 +33,13 @@ impl<'c, C: Config> Threads<'c, C> {
     /// Create a thread and run it in one request.
     pub async fn create_and_run(
         &self,
-        request: CreateThreadAndRunRequest,
+        request: &CreateThreadAndRunRequest,
     ) -> Result<RunObject, OpenAIError> {
         self.client.post("/threads/runs", request).await
     }
 
     /// Create a thread.
-    pub async fn create(&self, request: CreateThreadRequest) -> Result<ThreadObject, OpenAIError> {
+    pub async fn create(&self, request: &CreateThreadRequest) -> Result<ThreadObject, OpenAIError> {
         self.client.post("/threads", request).await
     }
 
@@ -52,7 +52,7 @@ impl<'c, C: Config> Threads<'c, C> {
     pub async fn update(
         &self,
         thread_id: &str,
-        request: ModifyThreadRequest,
+        request: &ModifyThreadRequest,
     ) -> Result<ThreadObject, OpenAIError> {
         self.client
             .post(&format!("/threads/{thread_id}"), request)

--- a/async-openai/src/types/embedding.rs
+++ b/async-openai/src/types/embedding.rs
@@ -49,7 +49,7 @@ pub struct CreateEmbeddingRequest {
 
     /// The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dimensions: Option<u32>
+    pub dimensions: Option<u32>,
 }
 
 /// Represents an embedding vector returned by embedding endpoint.

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -619,7 +619,7 @@ impl Default for ChatCompletionRequestUserMessageContent {
 impl async_convert::TryFrom<CreateTranscriptionRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
 
-    async fn try_from(request: CreateTranscriptionRequest) -> Result<Self, Self::Error> {
+    async fn try_from(request: &CreateTranscriptionRequest) -> Result<Self, Self::Error> {
         let audio_part = create_file_part(request.file.source).await?;
 
         let mut form = reqwest::multipart::Form::new()
@@ -650,7 +650,7 @@ impl async_convert::TryFrom<CreateTranscriptionRequest> for reqwest::multipart::
 impl async_convert::TryFrom<CreateTranslationRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
 
-    async fn try_from(request: CreateTranslationRequest) -> Result<Self, Self::Error> {
+    async fn try_from(request: &CreateTranslationRequest) -> Result<Self, Self::Error> {
         let audio_part = create_file_part(request.file.source).await?;
 
         let mut form = reqwest::multipart::Form::new()
@@ -676,7 +676,7 @@ impl async_convert::TryFrom<CreateTranslationRequest> for reqwest::multipart::Fo
 impl async_convert::TryFrom<CreateImageEditRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
 
-    async fn try_from(request: CreateImageEditRequest) -> Result<Self, Self::Error> {
+    async fn try_from(request: &CreateImageEditRequest) -> Result<Self, Self::Error> {
         let image_part = create_file_part(request.image.source).await?;
 
         let mut form = reqwest::multipart::Form::new()
@@ -718,7 +718,7 @@ impl async_convert::TryFrom<CreateImageEditRequest> for reqwest::multipart::Form
 impl async_convert::TryFrom<CreateImageVariationRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
 
-    async fn try_from(request: CreateImageVariationRequest) -> Result<Self, Self::Error> {
+    async fn try_from(request: &CreateImageVariationRequest) -> Result<Self, Self::Error> {
         let image_part = create_file_part(request.image.source).await?;
 
         let mut form = reqwest::multipart::Form::new().part("image", image_part);
@@ -750,10 +750,10 @@ impl async_convert::TryFrom<CreateImageVariationRequest> for reqwest::multipart:
 }
 
 #[async_convert::async_trait]
-impl async_convert::TryFrom<CreateFileRequest> for reqwest::multipart::Form {
+impl<'a> async_convert::TryFrom<&'a CreateFileRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
 
-    async fn try_from(request: CreateFileRequest) -> Result<Self, Self::Error> {
+    async fn try_from(request: &'a CreateFileRequest) -> Result<Self, Self::Error> {
         let file_part = create_file_part(request.file.source).await?;
         let form = reqwest::multipart::Form::new()
             .part("file", file_part)

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use crate::{
+    async_convert,
     download::{download_url, save_b64},
     error::OpenAIError,
     types::InputSource,

--- a/async-openai/tests/boxed_future.rs
+++ b/async-openai/tests/boxed_future.rs
@@ -8,35 +8,43 @@ use async_openai::Client;
 async fn boxed_future_test() {
     fn interpret_bool(token_stream: &mut CompletionResponseStream) -> BoxFuture<'_, bool> {
         async move {
-            while let Some(response) = token_stream.next().await {
-                match response {
-                    Ok(response) => {
-                        let token_str = &response.choices[0].text.trim();
+            // collect all responses from the stream
+            let mut response = String::new();
+            while let Some(next_token) = token_stream.next().await {
+                match next_token {
+                    Ok(next_token) => {
+                        let token_str = &next_token.choices[0].text.trim();
                         if !token_str.is_empty() {
-                            return token_str.contains("yes") || token_str.contains("Yes");
+                            response.push_str(token_str);
+                            response.push_str(" ");
                         }
                     }
                     Err(e) => eprintln!("Error: {e}"),
                 }
             }
-            false
+            println!("Response: {}", response);
+            return response.contains("yes") || response.contains("Yes");
         }
         .boxed()
     }
 
     let client = Client::new();
 
-    let request = CreateCompletionRequestArgs::default()
-        .model("text-babbage-001")
+    let mut request = CreateCompletionRequestArgs::default()
+        .model("davinci-002")
         .n(1)
-        .prompt("does 2 and 2 add to four? (yes/no):\n")
+        .prompt("yes no yes no yes no")
         .stream(true)
         .logprobs(3)
         .max_tokens(64_u16)
         .build()
         .unwrap();
 
-    let mut stream = client.completions().create_stream(request).await.unwrap();
+    let mut stream = client
+        .completions()
+        .create_stream(&mut request)
+        .await
+        .unwrap();
 
     let result = interpret_bool(&mut stream).await;
     assert!(result);

--- a/async-openai/tests/whisper.rs
+++ b/async-openai/tests/whisper.rs
@@ -8,7 +8,7 @@ async fn transcribe_test() {
 
     let request = CreateTranscriptionRequestArgs::default().build().unwrap();
 
-    let response = client.audio().transcribe(request).await;
+    let response = client.audio().transcribe(&request).await;
 
     assert_err!(response); // FileReadError("cannot extract file name from ")
 }
@@ -21,7 +21,7 @@ async fn transcribe_sendable_test() {
     let transcribe = tokio::spawn(async move {
         let request = CreateTranscriptionRequestArgs::default().build().unwrap();
 
-        client.audio().transcribe(request).await
+        client.audio().transcribe(&request).await
     });
 
     let response = transcribe.await.unwrap();
@@ -35,7 +35,7 @@ async fn translate_test() {
 
     let request = CreateTranslationRequestArgs::default().build().unwrap();
 
-    let response = client.audio().translate(request).await;
+    let response = client.audio().translate(&request).await;
 
     assert_err!(response); // FileReadError("cannot extract file name from ")
 }
@@ -48,7 +48,7 @@ async fn translate_sendable_test() {
     let translate = tokio::spawn(async move {
         let request = CreateTranslationRequestArgs::default().build().unwrap();
 
-        client.audio().translate(request).await
+        client.audio().translate(&request).await
     });
 
     let response = translate.await.unwrap();


### PR DESCRIPTION
I wish to retain control over the `CreateChatCompletionRequest` for logging and caching purposes after the call is made. Since the `create` function doesn't actually need to own any of the data in the request, it can simply borrow it instead.

This PR would unfortunately break the current API, but I'd like to bring it to your attention as a consideration for the next breaking release.