### PR TITLE
Added dimensions param to embedding request

### DIFF
--- a/async-openai/src/embedding.rs
+++ b/async-openai/src/embedding.rs
@@ -30,6 +30,7 @@ impl<'c, C: Config> Embeddings<'c, C> {
 #[cfg(test)]
 mod tests {
     use crate::{types::CreateEmbeddingRequestArgs, Client};
+    use crate::types::{CreateEmbeddingResponse, Embedding};
 
     #[tokio::test]
     async fn test_embedding_string() {
@@ -104,5 +105,26 @@ mod tests {
         let response = client.embeddings().create(request).await;
 
         assert!(response.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_embedding_with_reduced_dimensions() {
+        let client = Client::new();
+        let dimensions = 256u32;
+        let request = CreateEmbeddingRequestArgs::default()
+            .model("text-embedding-3-small")
+            .input("The food was delicious and the waiter...")
+            .dimensions(dimensions)
+            .build()
+            .unwrap();
+
+        let response = client.embeddings().create(request).await;
+
+        assert!(response.is_ok());
+
+        let CreateEmbeddingResponse { mut data, ..} = response.unwrap();
+        assert_eq!(data.len(), 1);
+        let Embedding { embedding, .. } = data.pop().unwrap();
+        assert_eq!(embedding.len(), dimensions as usize);
     }
 }

--- a/async-openai/src/types/embedding.rs
+++ b/async-openai/src/types/embedding.rs
@@ -46,6 +46,10 @@ pub struct CreateEmbeddingRequest {
     ///  to monitor and detect abuse. [Learn more](https://platform.openai.com/docs/usage-policies/end-user-ids).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+
+    /// The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dimensions: Option<u32>
 }
 
 /// Represents an embedding vector returned by embedding endpoint.


### PR DESCRIPTION
Added the dimensions param to the embedding request so that shortened embeddings can optionally be requested.