### PR TITLE
Add usage information to the run object

### DIFF
--- a/async-openai/src/types/run.rs
+++ b/async-openai/src/types/run.rs
@@ -53,6 +53,10 @@ pub struct RunObject {
     /// The list of [File](https://platform.openai.com/docs/api-reference/files) IDs the [assistant](/docs/api-reference/assistants) used for this run.
     pub file_ids: Vec<String>,
 
+    /// Usage information for the [run](https://platform.openai.com/docs/api-reference/runs/step-object#runs/object-usage).
+    /// Usage information is available when the run reaches a terminal state.
+    pub usage: Option<RunUsage>,
+
     pub metadata: Option<HashMap<String, serde_json::Value>>,
 }
 
@@ -105,6 +109,14 @@ pub struct LastError {
 pub enum LastErrorCode {
     ServerError,
     RateLimitExceeded,
+}
+
+#[derive(Clone, Serialize, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct RunUsage {
+    pub completion_tokens: usize,
+    pub prompt_tokens: usize,
+    pub total_tokens: usize,
 }
 
 #[derive(Clone, Serialize, Default, Debug, Deserialize, Builder, PartialEq)]


### PR DESCRIPTION
OpenAI provide usage information on the run object, this PR adds that information to the RunObject in async_openai.

OpenAI documentation:
https://platform.openai.com/docs/api-reference/runs/object#runs/object-usage