### PR TITLE
Making the sleep asynchronous compatible in an example

### DIFF
--- a/examples/assistants/src/main.rs
+++ b/examples/assistants/src/main.rs
@@ -135,7 +135,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 }
             }
             //wait for 1 second before checking the status again
-            std::thread::sleep(std::time::Duration::from_secs(1));
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         }
     }
 


### PR DESCRIPTION
Resolves #194 .

Using `std::thread::sleep` in async code is not advisable. `tokio::time::sleep` is preferred instead. This PR contains this small change. 

Tested the code change by running locally - works as expected!