### PR TITLE
Add vision-chat example

### DIFF
--- a/examples/vision-chat/Cargo.toml
+++ b/examples/vision-chat/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "vision-chat"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-openai = { path = "../../async-openai" }
+serde_json = "1.0.114"
+tokio = { version = "1.36.0", features = ["full"] }

--- a/examples/vision-chat/README.md
+++ b/examples/vision-chat/README.md
@@ -1,0 +1,5 @@
+### Output
+
+> Response:
+>
+> 0: Role: assistant Content: "This is an image of a wooden boardwalk trail extending through a lush green meadow or wetland area. The sky is partly cloudy with a rich blue color, and it seems to be a bright sunny day. This type of boardwalk is often constructed in natural areas to allow people to enjoy the scenery without disturbing the local flora and fauna. It provides a clear path through potentially marshy or sensitive ecosystems and can be found in nature reserves, parks, or conservation areas."

--- a/examples/vision-chat/src/main.rs
+++ b/examples/vision-chat/src/main.rs
@@ -1,0 +1,55 @@
+use std::error::Error;
+
+use async_openai::{
+    types::{
+        ChatCompletionRequestMessageContentPartImageArgs,
+        ChatCompletionRequestMessageContentPartTextArgs, ChatCompletionRequestUserMessageArgs,
+        CreateChatCompletionRequestArgs, ImageUrlArgs, ImageUrlDetail,
+    },
+    Client,
+};
+
+/// https://platform.openai.com/docs/guides/vision - quickstart
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let client = Client::new();
+
+    let image_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg";
+
+    let request = CreateChatCompletionRequestArgs::default()
+        .model("gpt-4-vision-preview")
+        .max_tokens(300_u16)
+        .messages([ChatCompletionRequestUserMessageArgs::default()
+            .content(vec![
+                ChatCompletionRequestMessageContentPartTextArgs::default()
+                    .text("What is this image?")
+                    .build()?
+                    .into(),
+                ChatCompletionRequestMessageContentPartImageArgs::default()
+                    .image_url(
+                        ImageUrlArgs::default()
+                            .url(image_url)
+                            .detail(ImageUrlDetail::High)
+                            .build()?,
+                    )
+                    .build()?
+                    .into(),
+            ])
+            .build()?
+            .into()])
+        .build()?;
+
+    println!("{}", serde_json::to_string(&request).unwrap());
+
+    let response = client.chat().create(request).await?;
+
+    println!("\nResponse:\n");
+    for choice in response.choices {
+        println!(
+            "{}: Role: {}  Content: {:?}",
+            choice.index, choice.message.role, choice.message.content.unwrap_or_default()
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
The example directory currently lacks an example that matches the quickstart from https://platform.openai.com/docs/guides/vision 

This PR adds the quickstart example. Notably it shows how to use `ChatCompletionRequestMessageContentPartTextArgs`, `ChatCompletionRequestMessageContentPartImageArgs`, `ImageUrlArgs` and `ImageUrlDetail`. 

I followed the logic from the standard chat example.
Please let me know if I can improve the PR and thank you very much for creating this crate. 
