### PR TITLE
fix FileCitation deserialization

### DIFF
--- a/async-openai/src/types/message.rs
+++ b/async-openai/src/types/message.rs
@@ -144,7 +144,7 @@ pub struct FileCitation {
     /// The ID of the specific File the citation is from.
     pub file_id: String,
     /// The specific quote in the file.
-    pub quote: String,
+    pub quote: Option<String>,
 }
 
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq)]


### PR DESCRIPTION
Made `pub quote: Option<String>`, optional as suggested, seems to work fine now, cheers