### PR TITLE
Chat types - Manage empty string in finish_reason property

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -524,6 +524,9 @@ pub enum FinishReason {
     ToolCalls,
     ContentFilter,
     FunctionCall,
+    // In some cases like ollama openai endpoint, finish_reason property could be an empty string
+    #[serde(rename = "")]
+    Empty,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]


### PR DESCRIPTION
This pull request allows to manage empty string in finish_reason property

I encountered this case with the OpenAI API of Ollama in version 1.35.

Before that the API returned a null value for this field.

**Before :**

```json
{
  "id": "chatcmpl-351",
  "object": "chat.completion.chunk",
  "created": 1715436723,
  "model": "llama3",
  "system_fingerprint": "fp_ollama",
  "choices": [
    {
      "index": 0,
      "delta": {
        "role": "assistant",
        "content": "Je"
      },
      "finish_reason": null
    }
  ]
}
```


**After :** 

```json
{
  "id": "chatcmpl-351",
  "object": "chat.completion.chunk",
  "created": 1715436723,
  "model": "llama3",
  "system_fingerprint": "fp_ollama",
  "choices": [
    {
      "index": 0,
      "delta": {
        "role": "assistant",
        "content": "Je"
      },
      "finish_reason": ""
    }
  ]
}
```

I have not seen unit tests on the typing part of the library, if you ever accept the modification, tell me if I have to add some somewhere.

I tested the modification with the Ollama API in version 1.35 and 1.36, the PR solve the problem.

