### PR TITLE
fix: Update vector store file chunking strategy to use StaticChunkingStrategy

### DIFF
--- a/async-openai/src/types/vector_store.rs
+++ b/async-openai/src/types/vector_store.rs
@@ -18,8 +18,7 @@ pub struct CreateVectorStoreRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_ids: Option<Vec<String>>,
     /// The name of the vector store.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
 
     /// The expiration policy for a vector store.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -192,7 +191,7 @@ pub enum VectorStoreFileErrorCode {
 pub enum VectorStoreFileObjectChunkingStrategy {
     /// This is returned when the chunking strategy is unknown. Typically, this is because the file was indexed before the `chunking_strategy` concept was introduced in the API.
     Other,
-    Static(StaticChunkingStrategy),
+    Static{ r#static: StaticChunkingStrategy },
 }
 
 #[derive(Debug, Serialize, Default, Clone, Builder, PartialEq)]

--- a/async-openai/src/types/vector_store.rs
+++ b/async-openai/src/types/vector_store.rs
@@ -18,7 +18,8 @@ pub struct CreateVectorStoreRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_ids: Option<Vec<String>>,
     /// The name of the vector store.
-    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 
     /// The expiration policy for a vector store.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -62,7 +63,7 @@ pub struct VectorStoreObject {
     /// The Unix timestamp (in seconds) for when the vector store was created.
     pub created_at: u32,
     /// The name of the vector store.
-    pub name: String,
+    pub name: Option<String>,
     /// The total number of bytes used by the files in the vector store.
     pub usage_bytes: u64,
     pub file_counts: VectorStoreFileCounts,

--- a/async-openai/src/vector_store_files.rs
+++ b/async-openai/src/vector_store_files.rs
@@ -107,7 +107,13 @@ mod tests {
                 metadata: None
             })
             .await?;
+    let vector_store_file = client
+        .vector_stores()
+        .files(&vector_store_handle.id)
+        .retrieve(&file_handle.id)
+        .await?;
 
+    assert_eq!(vector_store_file.id, file_handle.id);
         // Delete the vector store
         client
             .vector_stores()

--- a/async-openai/src/vector_store_files.rs
+++ b/async-openai/src/vector_store_files.rs
@@ -101,7 +101,7 @@ mod tests {
             .vector_stores()
             .create( CreateVectorStoreRequest {
                 file_ids: None,
-                name: String::from("meowww"),
+                name: None,
                 expires_after: None,
                 chunking_strategy: None,
                 metadata: None

--- a/async-openai/src/vector_store_files.rs
+++ b/async-openai/src/vector_store_files.rs
@@ -100,22 +100,13 @@ mod tests {
         let vector_store_handle = client
             .vector_stores()
             .create( CreateVectorStoreRequest {
-                file_ids: None,
+                file_ids: Some(vec![file_handle.id.clone()]),
                 name: None,
                 expires_after: None,
                 chunking_strategy: None,
                 metadata: None
             })
             .await?;
-
-        // Attach the file to the vector store
-        client
-            .vector_stores()
-            .files(&vector_store_handle.id)
-            .create(CreateVectorStoreFileRequest {
-                file_id: file_handle.id.clone(),
-                chunking_strategy: None
-            }).await?;
 
         // Delete the vector store
         client


### PR DESCRIPTION
This targets the changes mentioned in #229, because OpenAI requires a non-null name when creating a vector store. This also fixes attaching a file to a vector store, where it would fail to deserialize. Also adds a test for both errors to catch them during development in the future!

Fixes #229