### PR TITLE
fix: skip serialization to null if field is none in `CreateRunRequest`

### DIFF
--- a/async-openai/src/types/run.rs
+++ b/async-openai/src/types/run.rs
@@ -192,45 +192,57 @@ pub struct CreateRunRequest {
     pub model: Option<String>,
 
     /// Overrides the [instructions](https://platform.openai.com/docs/api-reference/assistants/createAssistant) of the assistant. This is useful for modifying the behavior on a per-run basis.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
 
     /// Appends additional instructions at the end of the instructions for the run. This is useful for modifying the behavior on a per-run basis without overriding other instructions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_instructions: Option<String>,
 
     /// Adds additional messages to the thread before creating the run.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_messages: Option<Vec<CreateMessageRequest>>,
 
     /// Override the tools the assistant can use for this run. This is useful for modifying the behavior on a per-run basis.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<AssistantTools>>,
 
     pub metadata: Option<HashMap<String, serde_json::Value>>,
 
     /// The sampling temperature used for this run. If not set, defaults to 1.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
 
     ///  An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
     ///
     /// We generally recommend altering this or temperature but not both.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub top_p: Option<f32>,
 
     /// If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,
 
     /// The maximum number of prompt tokens that may be used over the course of the run. The run will make a best effort to use only the number of prompt tokens specified, across multiple turns of the run. If the run exceeds the number of prompt tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_prompt_tokens: Option<u32>,
 
     /// The maximum number of completion tokens that may be used over the course of the run. The run will make a best effort to use only the number of completion tokens specified, across multiple turns of the run. If the run exceeds the number of completion tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_completion_tokens: Option<u32>,
 
     /// Controls for how a thread will be truncated prior to the run. Use this to control the intial context window of the run.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub truncation_strategy: Option<TruncationObject>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<AssistantsApiToolChoiceOption>,
 
     /// Whether to enable [parallel function calling](https://platform.openai.com/docs/guides/function-calling/parallel-function-calling) during tool use.
-    #[serde(default)]
-    pub parallel_tool_calls: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parallel_tool_calls: Option<bool>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<AssistantsApiResponseFormatOption>,
 }
 

--- a/async-openai/src/types/run.rs
+++ b/async-openai/src/types/run.rs
@@ -228,7 +228,8 @@ pub struct CreateRunRequest {
     pub tool_choice: Option<AssistantsApiToolChoiceOption>,
 
     /// Whether to enable [parallel function calling](https://platform.openai.com/docs/guides/function-calling/parallel-function-calling) during tool use.
-    pub parallel_tool_calls: Option<bool>,
+    #[serde(default)]
+    pub parallel_tool_calls: bool,
 
     pub response_format: Option<AssistantsApiResponseFormatOption>,
 }


### PR DESCRIPTION
Fix for issue #234