### PR TITLE
add unsupported_file error type for vector_store.file

### DIFF
--- a/async-openai/src/types/vector_store.rs
+++ b/async-openai/src/types/vector_store.rs
@@ -184,6 +184,7 @@ pub enum VectorStoreFileErrorCode {
     FileNotFound,
     ParsingError,
     UnhandledMimeType,
+    UnsupportedFile,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]


### PR DESCRIPTION
I tried listing my vector store file and received the following error.
```
value: JSONDeserialize(Error("unknown variant `unsupported_file`, expected one of `internal_error`,
 `file_not_found`, `parsing_error`, `unhandled_mime_type`", line: 204, column: 34))
```

Doing the API call manually I saw that the status code returned is not yet supported in `async-aponai`.

```bash
curl https://api.openai.com/v1/vector_stores/vs_Y.../files -H 'OpenAI-Beta: assistants=v2'
```
the response.
```json
    {
      "id": "file-hAV...",
      "object": "vector_store.file",
      "usage_bytes": 0,
      "created_at": 1722070582,
      "vector_store_id": "vs_....",
      "status": "failed",
      "last_error": {
        "code": "unsupported_file",
        "message": "The file type is not supported."
      },
      "chunking_strategy": {
        "type": "static",
        "static": {
          "max_chunk_size_tokens": 800,
          "chunk_overlap_tokens": 400
        }
      }
    },
```

So I added the status code to the enum.