### PR TITLE
Fix incompatibility with API requirements

### DIFF
--- a/async-openai/src/types/assistant.rs
+++ b/async-openai/src/types/assistant.rs
@@ -38,9 +38,9 @@ pub struct CreateAssistantToolResources {
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq, Default)]
 pub struct CreateAssistantToolFileSearchResources {
     ///  The [vector store](https://platform.openai.com/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.
-    pub vector_store_ids: Vec<String>,
+    pub vector_store_ids: Option<Vec<String>>,
     /// A helper to create a [vector store](https://platform.openai.com/docs/api-reference/vector-stores/object) with file_ids and attach it to this assistant. There can be a maximum of 1 vector store attached to the assistant.
-    pub vector_stores: Vec<AssistantVectorStore>,
+    pub vector_stores: Option<Vec<AssistantVectorStore>>,
 }
 
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq, Default)]


### PR DESCRIPTION
For `CreateAssistantToolFileSearchResources` struct the API expects only one of the two fields to be used. Even an empty array is not accepted if the other field contains a value. Thus making both `vector_store_ids` and `vector_stores` optional is the way to go.

Fixes 64bit/async-openai#251