### PR TITLE
Fix service_tier serialization for CreateChatCompletionRequest

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -537,6 +537,7 @@ pub struct CreateChatCompletionRequest {
     /// - When not set, the default behavior is 'auto'.
     ///
     /// When this parameter is set, the response body will include the `service_tier` utilized.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<ServiceTier>,
 
     /// Up to 4 sequences where the API will stop generating further tokens.


### PR DESCRIPTION
As per the API reference page on OpenAI's website, the parameter can be excluded from the request.
https://platform.openai.com/docs/api-reference/chat