### PR TITLE
Fix content, refusal serialization for CreateChatCompletionRequest

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -245,8 +245,10 @@ pub struct ChatCompletionRequestUserMessage {
 #[builder(build_fn(error = "OpenAIError"))]
 pub struct ChatCompletionRequestAssistantMessage {
     /// The contents of the assistant message. Required unless `tool_calls` or `function_call` is specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<ChatCompletionRequestAssistantMessageContent>,
     /// The refusal message by the assistant.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub refusal: Option<String>,
     /// An optional name for the participant. Provides the model information to differentiate between participants of the same role.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
They are optional per the openai docs.