### PR TITLE
make prompt_tokens_details and completion_tokens_details optional

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -94,9 +94,11 @@ pub struct CompletionUsage {
     /// Total number of tokens used in the request (prompt + completion).
     pub total_tokens: u32,
     /// Breakdown of tokens used in the prompt.
-    pub prompt_tokens_details: PromptTokenDetails,
+    #[serde(default)]
+    pub prompt_tokens_details: Option<PromptTokenDetails>,
     /// Breakdown of tokens used in a completion.
-    pub completion_tokens_details: CompletionTokenDetails,
+    #[serde(default)]
+    pub completion_tokens_details: Option<CompletionTokenDetails>,
 }
 
 /// Breakdown of tokens used in a completion.


### PR DESCRIPTION
Legacy models such as GPT3.5 doesn't return these fields, so we make them optional.