### PR TITLE
Fix chunking strategy serialization and field visibility

### DIFF
--- a/async-openai/src/types/assistant.rs
+++ b/async-openai/src/types/assistant.rs
@@ -63,7 +63,10 @@ pub enum AssistantVectorStoreChunkingStrategy {
     #[serde(rename = "auto")]
     Auto,
     #[serde(rename = "static")]
-    Static(StaticChunkingStrategy),
+    Static {
+        #[serde(rename = "static")]
+        config: StaticChunkingStrategy,
+    },
 }
 
 /// Static Chunking Strategy

--- a/async-openai/src/types/assistant.rs
+++ b/async-openai/src/types/assistant.rs
@@ -60,7 +60,9 @@ pub struct AssistantVectorStore {
 pub enum AssistantVectorStoreChunkingStrategy {
     /// The default strategy. This strategy currently uses a `max_chunk_size_tokens` of `800` and `chunk_overlap_tokens` of `400`.
     #[default]
+    #[serde(rename = "auto")]
     Auto,
+    #[serde(rename = "static")]
     Static(StaticChunkingStrategy),
 }
 
@@ -68,11 +70,11 @@ pub enum AssistantVectorStoreChunkingStrategy {
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq, Default)]
 pub struct StaticChunkingStrategy {
     /// The maximum number of tokens in each chunk. The default value is `800`. The minimum value is `100` and the maximum value is `4096`.
-    max_chunk_size_tokens: u16,
+    pub max_chunk_size_tokens: u16,
     /// The number of tokens that overlap between chunks. The default value is `400`.
     ///
     /// Note that the overlap must not exceed half of `max_chunk_size_tokens`.
-    chunk_overlap_tokens: u16,
+    pub chunk_overlap_tokens: u16,
 }
 
 /// Represents an `assistant` that can call the model and use tools.

--- a/async-openai/src/types/vector_store.rs
+++ b/async-openai/src/types/vector_store.rs
@@ -42,7 +42,10 @@ pub enum VectorStoreChunkingStrategy {
     #[serde(rename = "auto")]
     Auto,
     #[serde(rename = "static")]
-    Static(StaticChunkingStrategy),
+    Static {
+        #[serde(rename = "static")]
+        config: StaticChunkingStrategy,
+    },
 }
 
 /// Vector store expiration policy

--- a/async-openai/src/types/vector_store.rs
+++ b/async-openai/src/types/vector_store.rs
@@ -39,7 +39,9 @@ pub struct CreateVectorStoreRequest {
 pub enum VectorStoreChunkingStrategy {
     /// The default strategy. This strategy currently uses a `max_chunk_size_tokens` of `800` and `chunk_overlap_tokens` of `400`.
     #[default]
+    #[serde(rename = "auto")]
     Auto,
+    #[serde(rename = "static")]
     Static(StaticChunkingStrategy),
 }
 


### PR DESCRIPTION
# Fix chunking strategy serialization and field visibility

## Description
This PR fixes three issues with chunking strategies in the vector stores API:

1. Incorrect serialization format for static chunking strategy
2. Incorrect casing in enum variant serialization ("Static" vs "static")
3. Private fields preventing users from setting chunking parameters

## Changes

### Serialization Fix
The OpenAI API expects the static chunking configuration to be nested under a "static" field, but the current implementation serializes it directly. This causes the error:
```
"Missing required parameter: 'chunking_strategy.static'."
```

Additionally, the enum variants were serializing with incorrect casing, causing:
```
"Invalid value: 'Static'. Supported values are: 'auto' and 'static'."
```

Changed from:
```rust
#[derive(Clone, Serialize, Debug, Deserialize, PartialEq, Default)]
#[serde(tag = "type")]
pub enum VectorStoreChunkingStrategy {
    #[default]
    Auto,
    Static(StaticChunkingStrategy),
}
```

To:
```rust
#[derive(Clone, Serialize, Debug, Deserialize, PartialEq, Default)]
#[serde(tag = "type")]
pub enum VectorStoreChunkingStrategy {
    #[default]
    #[serde(rename = "auto")]
    Auto,
    #[serde(rename = "static")]
    Static {
        #[serde(rename = "static")]
        config: StaticChunkingStrategy,
    },
}
```

### Field Visibility
Made fields in `StaticChunkingStrategy` public to allow users to configure chunking parameters:

```rust
#[derive(Clone, Serialize, Debug, Deserialize, PartialEq, Default)]
pub struct StaticChunkingStrategy {
    pub max_chunk_size_tokens: u16,
    pub chunk_overlap_tokens: u16,
}
```