### PR TITLE
chore(deps)!: Update Secrecy

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -30,9 +30,9 @@ base64 = "0.22.1"
 futures = "0.3.30"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", features = [
-    "json",
-    "stream",
-    "multipart",
+  "json",
+  "stream",
+  "multipart",
 ], default-features = false }
 reqwest-eventsource = "0.6.0"
 serde = { version = "1.0.203", features = ["derive", "rc"] }
@@ -44,7 +44,7 @@ tokio-util = { version = "0.7.11", features = ["codec", "io-util"] }
 tracing = "0.1.40"
 derive_builder = "0.20.0"
 async-convert = "1.0.0"
-secrecy = { version = "0.8.0", features = ["serde"] }
+secrecy = { version = "0.10.3", features = ["serde"] }
 bytes = "1.6.0"
 eventsource-stream = "0.2.3"
 tokio-tungstenite = { version = "0.24.0", optional = true, default-features = false }

--- a/async-openai/src/config.rs
+++ b/async-openai/src/config.rs
@@ -1,6 +1,6 @@
 //! Client configurations: [OpenAIConfig] for OpenAI, [AzureConfig] for Azure OpenAI Service.
 use reqwest::header::{HeaderMap, AUTHORIZATION};
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 
 /// Default v1 API base url
@@ -22,7 +22,7 @@ pub trait Config: Clone {
 
     fn api_base(&self) -> &str;
 
-    fn api_key(&self) -> &Secret<String>;
+    fn api_key(&self) -> &SecretString;
 }
 
 /// Configuration for OpenAI API
@@ -30,7 +30,7 @@ pub trait Config: Clone {
 #[serde(default)]
 pub struct OpenAIConfig {
     api_base: String,
-    api_key: Secret<String>,
+    api_key: SecretString,
     org_id: String,
     project_id: String,
 }
@@ -68,7 +68,7 @@ impl OpenAIConfig {
 
     /// To use a different API key different from default OPENAI_API_KEY env var
     pub fn with_api_key<S: Into<String>>(mut self, api_key: S) -> Self {
-        self.api_key = Secret::from(api_key.into());
+        self.api_key = SecretString::from(api_key.into());
         self
     }
 
@@ -123,7 +123,7 @@ impl Config for OpenAIConfig {
         &self.api_base
     }
 
-    fn api_key(&self) -> &Secret<String> {
+    fn api_key(&self) -> &SecretString {
         &self.api_key
     }
 
@@ -139,7 +139,7 @@ pub struct AzureConfig {
     api_version: String,
     deployment_id: String,
     api_base: String,
-    api_key: Secret<String>,
+    api_key: SecretString,
 }
 
 impl Default for AzureConfig {
@@ -172,7 +172,7 @@ impl AzureConfig {
 
     /// To use a different API key different from default OPENAI_API_KEY env var
     pub fn with_api_key<S: Into<String>>(mut self, api_key: S) -> Self {
-        self.api_key = Secret::from(api_key.into());
+        self.api_key = SecretString::from(api_key.into());
         self
     }
 
@@ -187,10 +187,7 @@ impl Config for AzureConfig {
     fn headers(&self) -> HeaderMap {
         let mut headers = HeaderMap::new();
 
-        headers.insert(
-            "api-key",
-            self.api_key.expose_secret().as_str().parse().unwrap(),
-        );
+        headers.insert("api-key", self.api_key.expose_secret().parse().unwrap());
 
         headers
     }
@@ -206,7 +203,7 @@ impl Config for AzureConfig {
         &self.api_base
     }
 
-    fn api_key(&self) -> &Secret<String> {
+    fn api_key(&self) -> &SecretString {
         &self.api_key
     }
 


### PR DESCRIPTION
Updates Secrecy to the latest version. Because the api changed, this is unfortunately a breaking change (swiftide included 🤷).

However, probably best to keep secret managing libraries up to date.

Thanks for the great library, we use it *a lot*.