### PR TITLE
Fix parsing of inf strings

### DIFF
--- a/async-openai/src/types/realtime/session_resource.rs
+++ b/async-openai/src/types/realtime/session_resource.rs
@@ -37,8 +37,7 @@ pub enum TurnDetection {
 #[serde(untagged)]
 pub enum MaxResponseOutputTokens {
     Num(u16),
-    #[serde(rename = "inf")]
-    Inf,
+    Inf(String),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Server events `MaxResponseOutputTokens` will currently not parse:

```
called `Result::unwrap()` on an `Err` value: JSON decode error: data did not match any variant of untagged enum MaxResponseOutputTokens
```

This fixes the issue, though it's a hack as it doesn't validate that the string is `inf`. I'm not sure how to do that in serde without writing a custom deserializer/visitor.