### PR TITLE
Fix parsing of cancelled responses

### DIFF
--- a/async-openai/src/types/realtime/response_resource.rs
+++ b/async-openai/src/types/realtime/response_resource.rs
@@ -28,9 +28,15 @@ pub struct FailedError {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum IncompleteReason {
-    Interruption,
     MaxOutputTokens,
     ContentFilter,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum CancelledReason {
+    TurnDetected,
+    ClientCancelled,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -40,6 +46,8 @@ pub enum ResponseStatusDetail {
     Incomplete { reason: IncompleteReason },
     #[serde(rename = "failed")]
     Failed { error: Option<FailedError> },
+    #[serde(rename = "cancelled")]
+    Cancelled { reason: CancelledReason }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Without this, cancelled responses fail to parse:

```
called `Result::unwrap()` on an `Err` value: JSON decode error: unknown variant `cancelled`, expected `incomplete` or `failed`
```