### PR TITLE
remove async-convert and bump rust-version

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -6,7 +6,7 @@ categories = ["api-bindings", "web-programming", "asynchronous"]
 keywords = ["openai", "async", "openapi", "ai"]
 description = "Rust library for OpenAI"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.75"
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/64bit/async-openai"
@@ -43,7 +43,6 @@ tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.13", features = ["codec", "io-util"] }
 tracing = "0.1.41"
 derive_builder = "0.20.2"
-async-convert = "1.0.0"
 secrecy = { version = "0.10.3", features = ["serde"] }
 bytes = "1.9.0"
 eventsource-stream = "0.2.3"

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -7,7 +7,7 @@ use crate::{
     download::{download_url, save_b64},
     error::OpenAIError,
     types::InputSource,
-    util::{create_all_dir, create_file_part},
+    util::{create_all_dir, create_file_part, AsyncTryFrom},
 };
 
 use bytes::Bytes;
@@ -821,8 +821,7 @@ impl Default for ChatCompletionRequestToolMessageContent {
 
 // start: types to multipart from
 
-#[async_convert::async_trait]
-impl async_convert::TryFrom<CreateTranscriptionRequest> for reqwest::multipart::Form {
+impl AsyncTryFrom<CreateTranscriptionRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
 
     async fn try_from(request: CreateTranscriptionRequest) -> Result<Self, Self::Error> {
@@ -858,8 +857,7 @@ impl async_convert::TryFrom<CreateTranscriptionRequest> for reqwest::multipart::
     }
 }
 
-#[async_convert::async_trait]
-impl async_convert::TryFrom<CreateTranslationRequest> for reqwest::multipart::Form {
+impl AsyncTryFrom<CreateTranslationRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
 
     async fn try_from(request: CreateTranslationRequest) -> Result<Self, Self::Error> {
@@ -884,8 +882,7 @@ impl async_convert::TryFrom<CreateTranslationRequest> for reqwest::multipart::Fo
     }
 }
 
-#[async_convert::async_trait]
-impl async_convert::TryFrom<CreateImageEditRequest> for reqwest::multipart::Form {
+impl AsyncTryFrom<CreateImageEditRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
 
     async fn try_from(request: CreateImageEditRequest) -> Result<Self, Self::Error> {
@@ -926,8 +923,7 @@ impl async_convert::TryFrom<CreateImageEditRequest> for reqwest::multipart::Form
     }
 }
 
-#[async_convert::async_trait]
-impl async_convert::TryFrom<CreateImageVariationRequest> for reqwest::multipart::Form {
+impl AsyncTryFrom<CreateImageVariationRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
 
     async fn try_from(request: CreateImageVariationRequest) -> Result<Self, Self::Error> {
@@ -961,8 +957,7 @@ impl async_convert::TryFrom<CreateImageVariationRequest> for reqwest::multipart:
     }
 }
 
-#[async_convert::async_trait]
-impl async_convert::TryFrom<CreateFileRequest> for reqwest::multipart::Form {
+impl AsyncTryFrom<CreateFileRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
 
     async fn try_from(request: CreateFileRequest) -> Result<Self, Self::Error> {
@@ -974,8 +969,7 @@ impl async_convert::TryFrom<CreateFileRequest> for reqwest::multipart::Form {
     }
 }
 
-#[async_convert::async_trait]
-impl async_convert::TryFrom<AddUploadPartRequest> for reqwest::multipart::Form {
+impl AsyncTryFrom<AddUploadPartRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
 
     async fn try_from(request: AddUploadPartRequest) -> Result<Self, Self::Error> {

--- a/async-openai/src/util.rs
+++ b/async-openai/src/util.rs
@@ -7,6 +7,14 @@ use tokio_util::codec::{BytesCodec, FramedRead};
 use crate::error::OpenAIError;
 use crate::types::InputSource;
 
+pub(crate) trait AsyncTryFrom<T>: Sized {
+    /// The type returned in the event of a conversion error.
+    type Error;
+
+    /// Performs the conversion.
+    async fn try_from(value: T) -> Result<Self, Self::Error>;
+}
+
 pub(crate) async fn file_stream_body(source: InputSource) -> Result<Body, OpenAIError> {
     let body = match source {
         InputSource::Path { path } => {


### PR DESCRIPTION
This fixes #316 

As per https://github.com/rust-lang/api-guidelines/discussions/231, the increase of MSRV is not a breaking change, so there's no need for a major release.