### PR TITLE
Add `From<ChatCompletionRequestDeveloperMessage>` implementation for `ChatCompletionRequestMessage`

### DIFF
--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -553,6 +553,12 @@ impl From<ChatCompletionRequestSystemMessage> for ChatCompletionRequestMessage {
     }
 }
 
+impl From<ChatCompletionRequestDeveloperMessage> for ChatCompletionRequestMessage {
+    fn from(value: ChatCompletionRequestDeveloperMessage) -> Self {
+        Self::Developer(value)
+    }
+}
+
 impl From<ChatCompletionRequestAssistantMessage> for ChatCompletionRequestMessage {
     fn from(value: ChatCompletionRequestAssistantMessage) -> Self {
         Self::Assistant(value)


### PR DESCRIPTION
In trying to use the new `ChatCompletionRequestDeveloperMessage` added in #312, I found I couldn't use `.into()` to add it to `messages` because a `From<ChatCompletionRequestDeveloperMessage>` implementation for `ChatCompletionRequestMessage` wasn't available.