### PR TITLE
Add missing From impl for ChatCompletionRequestMessage, replace trivial From impls with derive_more

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -43,6 +43,7 @@ tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.13", features = ["codec", "io-util"] }
 tracing = "0.1.41"
 derive_builder = "0.20.2"
+derive_more = { version = "1.0.0", features = ["from"] }
 secrecy = { version = "0.10.3", features = ["serde"] }
 bytes = "1.9.0"
 eventsource-stream = "0.2.3"

--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, pin::Pin};
 
 use derive_builder::Builder;
+use derive_more::From;
 use futures::Stream;
 use serde::{Deserialize, Serialize};
 
@@ -376,7 +377,7 @@ pub struct ChatCompletionRequestFunctionMessage {
     pub name: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, From)]
 #[serde(tag = "role")]
 #[serde(rename_all = "lowercase")]
 pub enum ChatCompletionRequestMessage {

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -539,38 +539,6 @@ impl From<(String, serde_json::Value)> for ChatCompletionFunctions {
     }
 }
 
-// todo: write macro for bunch of same looking From trait implementations below
-
-impl From<ChatCompletionRequestUserMessage> for ChatCompletionRequestMessage {
-    fn from(value: ChatCompletionRequestUserMessage) -> Self {
-        Self::User(value)
-    }
-}
-
-impl From<ChatCompletionRequestSystemMessage> for ChatCompletionRequestMessage {
-    fn from(value: ChatCompletionRequestSystemMessage) -> Self {
-        Self::System(value)
-    }
-}
-
-impl From<ChatCompletionRequestAssistantMessage> for ChatCompletionRequestMessage {
-    fn from(value: ChatCompletionRequestAssistantMessage) -> Self {
-        Self::Assistant(value)
-    }
-}
-
-impl From<ChatCompletionRequestFunctionMessage> for ChatCompletionRequestMessage {
-    fn from(value: ChatCompletionRequestFunctionMessage) -> Self {
-        Self::Function(value)
-    }
-}
-
-impl From<ChatCompletionRequestToolMessage> for ChatCompletionRequestMessage {
-    fn from(value: ChatCompletionRequestToolMessage) -> Self {
-        Self::Tool(value)
-    }
-}
-
 impl From<ChatCompletionRequestUserMessageContent> for ChatCompletionRequestUserMessage {
     fn from(value: ChatCompletionRequestUserMessageContent) -> Self {
         Self {


### PR DESCRIPTION
`ChatCompletionRequestMessage` didn't have `From<ChatCompletionRequestDeveloperMessage>`

I went to add it, and found the TODO:

```
// todo: write macro for bunch of same looking From trait implementations below
```

The crate `derive_more` does this by deriving `From` for simple wrapper-branching enums like this.