### PR TITLE
Implement `From<serde_json::Error>` on `OpenAIError` enum

### DIFF
--- a/async-openai/src/error.rs
+++ b/async-openai/src/error.rs
@@ -11,7 +11,7 @@ pub enum OpenAIError {
     ApiError(ApiError),
     /// Error when a response cannot be deserialized into a Rust type
     #[error("failed to deserialize api response: {0}")]
-    JSONDeserialize(serde_json::Error),
+    JSONDeserialize(#[from] serde_json::Error),
     /// Error on the client side when saving file to file system
     #[error("failed to save file: {0}")]
     FileSaveError(String),


### PR DESCRIPTION
This resolves #324 

Simply implements the `From<serde_json::Error>` trait on the `OpenAIError` enum.