### PR TITLE
Fixed duplicated arguments in tool-call-stream example

### DIFF
--- a/examples/tool-call-stream/src/main.rs
+++ b/examples/tool-call-stream/src/main.rs
@@ -69,6 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             let tool_call_data = tool_call_chunk.clone();
 
                             let mut states_lock = states.lock().await;
+                            let tool_call_existed = states_lock.contains_key(&key);
                             let state = states_lock.entry(key).or_insert_with(|| {
                                 ChatCompletionMessageToolCall {
                                     id: tool_call_data.id.clone().unwrap_or_default(),
@@ -92,7 +93,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 .as_ref()
                                 .and_then(|f| f.arguments.as_ref())
                             {
-                                state.function.arguments.push_str(arguments);
+                                // Only update the arguments for existing tool calls because when inserting a new tool call, the arguments are already set
+                                if tool_call_existed {
+                                    state.function.arguments.push_str(arguments);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
When playing around with the tool-call-stream example in combination with [mistral's API](https://console.mistral.ai/) I encountered a strange bug where the arguments where duplicated (e.g. instead of `{ "city": "Berlin" }` I would always get `{ "city": "Berlin" }{ "city": "Berlin" }`).

This issue is caused by mistral's API streaming the arguments together with the tool call id and function name which in the example results in the `ChatCompletionMessageToolCall` being inserted including arguments and then the arguments would be concatenated to itself again.

The adjusted example in this PR fixes this issue.