### PR TITLE
Enable the use of OpenRouter reasoning models

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -798,6 +798,10 @@ pub struct CreateChatCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
 
+    /// Support extra_body for OpenRouter reasoning models
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_body: Option<serde_json::Value>,
+
     /// Deprecated in favor of `tool_choice`.
     ///
     /// Controls which (if any) function is called by the model.


### PR DESCRIPTION
It seems that many PRs handle reasoning support from deepseek or stuff. Adding `reasoning_effort` or checking `reasoning_content` won't work for OpenRouter, we have to add `"extra_body": { "include_reasoning":  true }` as well:

```rust
request: CreateChatCompletionRequestArgs
request.extra_body(serde_json::json!({
                    "include_reasoning": true,
                }));
```

As the output of OpenRouter is `reasoning` instead `reasoning_content`, #334 needs a patch as follow to make OpenRouter happy. @lijingrs would you mind adding an alias to the field? Like this:

```rust

pub struct ChatCompletionStreamResponseDelta {
     // ...
    #[serde(alias = "reasoning")]
    pub reasoning_content: Option<String>,
    // ...
}
```
 