### PR TITLE
Make ID optional in ChatCompletionResponse, Gemini doesn't have it

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -882,7 +882,7 @@ pub struct ChatChoice {
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
 pub struct CreateChatCompletionResponse {
     /// A unique identifier for the chat completion.
-    pub id: String,
+    pub id: Option<String>,
     /// A list of chat completion choices. Can be more than one if `n` is greater than 1.
     pub choices: Vec<ChatChoice>,
     /// The Unix timestamp (in seconds) of when the chat completion was created.
@@ -966,7 +966,7 @@ pub struct ChatChoiceStream {
 /// Represents a streamed chunk of a chat completion response returned by model, based on the provided input.
 pub struct CreateChatCompletionStreamResponse {
     /// A unique identifier for the chat completion. Each chunk has the same ID.
-    pub id: String,
+    pub id: Option<String>,
     /// A list of chat completion choices. Can contain more than one elements if `n` is greater than 1. Can also be empty for the last chunk if you set `stream_options: {"include_usage": true}`.
     pub choices: Vec<ChatChoiceStream>,
 


### PR DESCRIPTION
I was trying to get Google Gemini integrated and their openai compatible endpoint doesn't include an ID field. I've tested this change and it works.

Not sure if you are open to a PR like this as the ID is present in the OpenAI OpenAPI spec https://platform.openai.com/docs/api-reference/chat/get, and it is technically an issue with the Google Gemini OpenAI compatibility layer.