### PR TITLE
Add support for multiple image files in `CreateImageEditRequest`

### DIFF
--- a/async-openai/src/types/image.rs
+++ b/async-openai/src/types/image.rs
@@ -146,7 +146,7 @@ pub struct ImageInput {
 #[builder(build_fn(error = "OpenAIError"))]
 pub struct CreateImageEditRequest {
     /// The image to edit. Must be a valid PNG file, less than 4MB, and square. If mask is not provided, image must have transparency, which will be used as the mask.
-    pub image: ImageInput,
+    pub image: Vec<ImageInput>,
 
     /// A text description of the desired image(s). The maximum length is 1000 characters.
     pub prompt: String,

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -893,11 +893,13 @@ impl AsyncTryFrom<CreateImageEditRequest> for reqwest::multipart::Form {
     type Error = OpenAIError;
 
     async fn try_from(request: CreateImageEditRequest) -> Result<Self, Self::Error> {
-        let image_part = create_file_part(request.image.source).await?;
-
         let mut form = reqwest::multipart::Form::new()
-            .part("image", image_part)
             .text("prompt", request.prompt);
+
+        for image in request.image {
+            let image_part = create_file_part(image.source).await?;
+            form = form.part("image[]", image_part);
+        }
 
         if let Some(mask) = request.mask {
             let mask_part = create_file_part(mask.source).await?;


### PR DESCRIPTION
Fixes https://github.com/64bit/async-openai/issues/363