### PR TITLE
Expose a way to customize the path to the chat completions endpoint

### DIFF
--- a/async-openai/src/chat.rs
+++ b/async-openai/src/chat.rs
@@ -12,11 +12,21 @@ use crate::{
 /// Related guide: [Chat completions](https://platform.openai.com//docs/guides/text-generation)
 pub struct Chat<'c, C: Config> {
     client: &'c Client<C>,
+    path: String,
 }
 
 impl<'c, C: Config> Chat<'c, C> {
     pub fn new(client: &'c Client<C>) -> Self {
-        Self { client }
+        Self {
+            client,
+            path: "/chat/completions".to_string(),
+        }
+    }
+
+    /// Change the path to the chat completions route.
+    pub fn with_path(mut self, path: impl Into<String>) -> Self {
+        self.path = path.into();
+        self
     }
 
     /// Creates a model response for the given chat conversation. Learn more in
@@ -52,7 +62,7 @@ impl<'c, C: Config> Chat<'c, C> {
                 ));
             }
         }
-        self.client.post("/chat/completions", request).await
+        self.client.post(&self.path, request).await
     }
 
     /// Creates a completion for the chat message
@@ -83,6 +93,6 @@ impl<'c, C: Config> Chat<'c, C> {
 
             request.stream = Some(true);
         }
-        Ok(self.client.post_stream("/chat/completions", request).await)
+        Ok(self.client.post_stream(&self.path, request).await)
     }
 }


### PR DESCRIPTION
Some APIs are close to being compatible with this crate. The byot (bring your own type) feature is handy, but useless when the path is incompatible.

For example, [Ollama's chat completions route](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion) is close to the OpenAI API but reachable on the `/api/chat` route. On the other hand, Claude (Anthropic) is available through the [`/v1/messages` route](https://docs.anthropic.com/en/api/messages), which is also very close to being compatible with the OpenAI API.