### PR TITLE
Add instructions option to speech request

### DIFF
--- a/async-openai/src/types/audio.rs
+++ b/async-openai/src/types/audio.rs
@@ -188,7 +188,8 @@ pub struct CreateSpeechRequest {
     /// One of the available [TTS models](https://platform.openai.com/docs/models/tts): `tts-1` or `tts-1-hd`
     pub model: SpeechModel,
 
-    /// The voice to use when generating the audio. Supported voices are `alloy`, `ash`, `coral`, `echo`, `fable`, `onyx`, `nova`, `sage` and `shimmer`.
+    /// The voice to use when generating the audio. Supported voices are `alloy`, `ash`, `coral`, `echo`, `fable`, `onyx`, `nova`, `sage`, `shimmer` and `verse`.
+
     /// Previews of the voices are available in the [Text to speech guide](https://platform.openai.com/docs/guides/text-to-speech#voice-options).
     pub voice: Voice,
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11440,10 +11440,6 @@ components:
                     description: The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`. Previews of the voices are available in the [Text to speech guide](/docs/guides/text-to-speech/voice-options).
                     type: string
                     enum: ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
-                instructions:
-                    description: |
-                        Control the voice of your generated audio with additional instructions. Does not work with `tts-1` or `tts-1-hd`.
-                    type: string
                 response_format:
                     description: "The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`."
                     default: "mp3"


### PR DESCRIPTION
## Summary
- support the new `instructions` parameter for text-to-speech
- document this field in the OpenAPI spec

Note, I updated the OpenAPI spec manually - let me know if I should regenerate it instead.