### PR TITLE
replace backoff with backon

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -28,7 +28,7 @@ byot = []
 
 [dependencies]
 async-openai-macros = { path = "../async-openai-macros", version = "0.1.0" }
-backoff = { version = "0.4.0", features = ["tokio"] }
+backon = { version = "1.5.1", features = ["tokio"] }
 base64 = "0.22.1"
 futures = "0.3.31"
 rand = "0.8.5"


### PR DESCRIPTION
backoff is unmaintained https://rustsec.org/advisories/RUSTSEC-2025-0012 and it is recommended to use backon #264.

This is a breaking change.