### PR TITLE
Add extra_body to CreateChatCompletionRequest

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, pin::Pin};
 use derive_builder::Builder;
 use futures::Stream;
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
 use crate::error::OpenAIError;
 
@@ -868,6 +869,11 @@ pub struct CreateChatCompletionRequest {
     #[deprecated]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub functions: Option<Vec<ChatCompletionFunctions>>,
+
+    /// Add additional JSON properties to the request
+    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_body: Option<Map<String, Value>>,
 }
 
 /// Options for streaming response. Only set this when you set `stream: true`.


### PR DESCRIPTION
OpenAI's Python library allows adding extra arguments to the request body via the [`extra_body`](https://github.com/openai/openai-python/blob/56540b32873df335aca9270715a839c2a9770639/src/openai/resources/chat/completions/completions.py#L114) kwarg. This is useful to, e.g., [control thinking modes](https://qwen.readthedocs.io/en/latest/deployment/vllm.html#thinking-non-thinking-modes) for Qwen. This PR adds the `extra_body` field to `CreateChatCompletionRequest` to accomplish the same.