### PR TITLE
Responses API - add missing completed state

### DIFF
--- a/async-openai/src/types/responses.rs
+++ b/async-openai/src/types/responses.rs
@@ -940,6 +940,7 @@ pub enum FileSearchCallOutputStatus {
     Searching,
     Incomplete,
     Failed,
+    Completed,
 }
 
 /// A single result from a file search.


### PR DESCRIPTION
In the current Responses API implementation for the Vector Store, not all states are implemented. This PR is adding the missing state, so vector store lookups no longer fail with 
```
thread 'tokio-runtime-worker' panicked at src/main.rs:140:71:
called `Result::unwrap()` on an `Err` value: JSONDeserialize(Error("unknown variant `completed`, expected one of `in_progress`, `searching`, `incomplete`, `failed`", line: 28, column: 4))
```