### PR TITLE
Add missing voice Ballad to enum

### DIFF
--- a/async-openai/src/types/audio.rs
+++ b/async-openai/src/types/audio.rs
@@ -40,6 +40,7 @@ pub enum Voice {
     #[default]
     Alloy,
     Ash,
+    Ballad,
     Coral,
     Echo,
     Fable,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11439,6 +11439,7 @@ components:
                 voice:
                     description: The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`. Previews of the voices are available in the [Text to speech guide](/docs/guides/text-to-speech/voice-options).
                     type: string
+                    enum: ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
                 response_format:
                     description: "The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`."
                     default: "mp3"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11439,7 +11439,6 @@ components:
                 voice:
                     description: The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`. Previews of the voices are available in the [Text to speech guide](/docs/guides/text-to-speech/voice-options).
                     type: string
-                    enum: ["alloy", "echo", "fable", "onyx", "nova", "shimmer", "ash", "ballad", "coral", "sage"]
                 response_format:
                     description: "The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`."
                     default: "mp3"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11439,7 +11439,7 @@ components:
                 voice:
                     description: The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`. Previews of the voices are available in the [Text to speech guide](/docs/guides/text-to-speech/voice-options).
                     type: string
-                    enum: ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
+                    enum: ["alloy", "echo", "fable", "onyx", "nova", "shimmer", "ash", "ballad", "coral", "sage"]
                 response_format:
                     description: "The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`."
                     default: "mp3"


### PR DESCRIPTION
Hey folks. I was parsing a config file based on the voice options here: https://platform.openai.com/docs/guides/text-to-speech#voice-options
and I got an error that "ballad" is not an expected option. I added it to the enum. 

I didn't see any test to update. Let me know if there's anything missing.