### PR TITLE
feat: change Prompt integer variants from u16 to u32 for future compatability

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -11,9 +11,9 @@ use crate::error::OpenAIError;
 pub enum Prompt {
     String(String),
     StringArray(Vec<String>),
-    // Minimum value is 0, maximum value is 50256 (inclusive).
-    IntegerArray(Vec<u16>),
-    ArrayOfIntegerArray(Vec<Vec<u16>>),
+    // Minimum value is 0, maximum value is 4_294_967_295 (inclusive).
+    IntegerArray(Vec<u32>),
+    ArrayOfIntegerArray(Vec<Vec<u32>>),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -372,7 +372,7 @@ macro_rules! impl_from_for_integer_array {
 }
 
 impl_from_for_integer_array!(u32, EmbeddingInput);
-impl_from_for_integer_array!(u16, Prompt);
+impl_from_for_integer_array!(u32, Prompt);
 
 macro_rules! impl_from_for_array_of_integer_array {
     ($from_typ:ty, $to_typ:ty) => {
@@ -469,7 +469,7 @@ macro_rules! impl_from_for_array_of_integer_array {
 }
 
 impl_from_for_array_of_integer_array!(u32, EmbeddingInput);
-impl_from_for_array_of_integer_array!(u16, Prompt);
+impl_from_for_array_of_integer_array!(u32, Prompt);
 
 impl From<&str> for ChatCompletionFunctionCall {
     fn from(value: &str) -> Self {


### PR DESCRIPTION
## Summary

Updates the `Prompt` enum to use `u32` instead of `u16` for integer-based prompt representations. The change affects both `Prompt::IntegerArray` and `Prompt::ArrayOfIntegerArray` variants, as well as associated `impl_from_for_*` macro implementations.

## Motivation

The original use of `u16` may have been based on the assumption that token ID values would not exceed the vocabulary size of models like GPT-2 or GPT-3 (i.e. 50256 tokens). 

While that assumption held previously, newer models frequently exceed this range. Allowing `u32` values would enable inference libraries to use `u32` token IDs and larger vocabulary sizes without needing to truncate while batching.

I fully recognize this is a breaking change to the public API:
- Users of `Prompt::IntegerArray` or `Prompt::ArrayOfIntegerArray` with `u16` inputs will encounter compile-time errors
- Pattern matches and constructors relying on the `u16` variant types must be updated to use `u32`

However, I think that this is in line with the scope and mission of `async-openai` as the [OpenAI OpenAPI schema does not specify the maximum token ID value](https://github.com/openai/openai-openapi/blob/manual_spec/openapi.yaml#L19946). 

And while users of `Prompt::IntegerArray` or `Prompt::ArrayOfIntegerArray` with `u16` inputs will need to update, conversion of `u16` to `u32` is lossless and won't cause any runtime issues. And the benefits of future proofing and greater compatibility outweigh prioritizing smaller vocabulary sizes from the previous GPT-2/GPT-3 era.

Thank you for your consideration!