### PR TITLE
task: Add serialize impl for ApiError

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "async-openai"
+version = "0.28.3"
 authors = ["Himanshu Neema"]
 categories = ["api-bindings", "web-programming", "asynchronous"]
 keywords = ["openai", "async", "openapi", "ai"]

--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-openai"
-version = "0.28.3"
+version = "0.28.4"
 authors = ["Himanshu Neema"]
 categories = ["api-bindings", "web-programming", "asynchronous"]
 keywords = ["openai", "async", "openapi", "ai"]

--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "async-openai"
-version = "0.28.4"
 authors = ["Himanshu Neema"]
 categories = ["api-bindings", "web-programming", "asynchronous"]
 keywords = ["openai", "async", "openapi", "ai"]

--- a/async-openai/src/error.rs
+++ b/async-openai/src/error.rs
@@ -1,5 +1,5 @@
 //! Errors originating from API calls, parsing responses, and reading-or-writing to the file system.
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, thiserror::Error)]
 pub enum OpenAIError {
@@ -28,7 +28,7 @@ pub enum OpenAIError {
 }
 
 /// OpenAI API returns error object on failure
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ApiError {
     pub message: String,
     pub r#type: Option<String>,
@@ -62,9 +62,9 @@ impl std::fmt::Display for ApiError {
 }
 
 /// Wrapper to deserialize the error object nested in "error" JSON key
-#[derive(Debug, Deserialize)]
-pub(crate) struct WrappedError {
-    pub(crate) error: ApiError,
+#[derive(Debug, Deserialize, Serialize)]
+pub struct WrappedError {
+    pub error: ApiError,
 }
 
 pub(crate) fn map_deserialization_error(e: serde_json::Error, bytes: &[u8]) -> OpenAIError {

--- a/async-openai/src/lib.rs
+++ b/async-openai/src/lib.rs
@@ -103,7 +103,7 @@
 //! ```
 //! use async_openai::{Client, config::Config, config::OpenAIConfig};
 //! unsafe { std::env::set_var("OPENAI_API_KEY", "only for doc test") }
-//! 
+//!
 //! let openai_config = OpenAIConfig::default();
 //! // You can use `std::sync::Arc` to wrap the config as well
 //! let config = Box::new(openai_config) as Box<dyn Config>;


### PR DESCRIPTION
Hi! thanks for the great ilbrary! I would love to see if you'd be open to adding a `Serialize` impl to the `ApiError` type so it can round trip. 

I also bumped the Cargo.toml version so a new crate version could be published, if you are able to do that after merging that would be awesome. 

The diff in `async-openai/src/lib.rs` was from running `cargo fmt`
