### PR TITLE
fix: remove hardcoded mime_str

### DIFF
--- a/async-openai/src/util.rs
+++ b/async-openai/src/util.rs
@@ -52,10 +52,7 @@ pub(crate) async fn create_file_part(
         InputSource::VecU8 { filename, vec } => (Body::from(vec), filename),
     };
 
-    let file_part = reqwest::multipart::Part::stream(stream)
-        .file_name(file_name)
-        .mime_str("application/octet-stream")
-        .unwrap();
+    let file_part = reqwest::multipart::Part::stream(stream).file_name(file_name);
 
     Ok(file_part)
 }


### PR DESCRIPTION
OpenAI API seems to be accepting files without specifying mime to be "application/octet-stream"