### PR TITLE
fix<(responses)>: `parsing Error if multiple instructions are given`

### DIFF
--- a/async-openai/src/types/responses.rs
+++ b/async-openai/src/types/responses.rs
@@ -1326,6 +1326,16 @@ pub struct Usage {
     pub total_tokens: u32,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum ResponseInstructions {
+    /// if string is provided
+    Single(String),
+
+    /// if multiple instructions are provided
+    Multiple(Vec<InputMessage>),
+}
+
 /// The complete response returned by the Responses API.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Response {
@@ -1345,7 +1355,7 @@ pub struct Response {
 
     /// Instructions that were inserted as the first item in context.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub instructions: Option<String>,
+    pub instructions: Option<ResponseInstructions>,
 
     /// The value of `max_output_tokens` that was honored.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
While Using Responses api, I found that `instructions` Fields can be Listed response.

Expected: 
```json
{
  ...
  "instructions": "Structure My Json"
}
```


Response: 
```json
{
  "instructions": [
    {
      "type": "message",
      "content": [
        {
          "type": "input_text",
          "text": "You are ~~~~ ( hide ) ~~~ ract paragraphs, body text, bibliographic references, and image/table references,\n ~~~"
        }
      ],
      "role": "system"
    },
    {
      "type": "message",
      "content": [
        {
          "type": "input_text",
          "text": "structure my uploaded file"
        }
      ],
      "role": "user"
    }
  ]
}
```

So I Added Untagged enum 
```rust
#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
#[serde(untagged)]
pub enum ResponseInstructions {
  /// The instructions that were inserted as the first item in context.
  Single(String),

  Multiple(Vec<InputMessage>)
}
```