### PR TITLE
Fix Typo in AssistantStreamEvent Variant (`TreadCreated` → `ThreadCreated`)

### DIFF
--- a/async-openai/src/types/assistant_stream.rs
+++ b/async-openai/src/types/assistant_stream.rs
@@ -35,7 +35,7 @@ use super::{
 pub enum AssistantStreamEvent {
     /// Occurs when a new [thread](https://platform.openai.com/docs/api-reference/threads/object) is created.
     #[serde(rename = "thread.created")]
-    TreadCreated(ThreadObject),
+    ThreadCreated(ThreadObject),
     /// Occurs when a new [run](https://platform.openai.com/docs/api-reference/runs/object) is created.
     #[serde(rename = "thread.run.created")]
     ThreadRunCreated(RunObject),
@@ -119,7 +119,7 @@ impl TryFrom<eventsource_stream::Event> for AssistantStreamEvent {
         match value.event.as_str() {
             "thread.created" => serde_json::from_str::<ThreadObject>(value.data.as_str())
                 .map_err(|e| map_deserialization_error(e, value.data.as_bytes()))
-                .map(AssistantStreamEvent::TreadCreated),
+                .map(AssistantStreamEvent::ThreadCreated),
             "thread.run.created" => serde_json::from_str::<RunObject>(value.data.as_str())
                 .map_err(|e| map_deserialization_error(e, value.data.as_bytes()))
                 .map(AssistantStreamEvent::ThreadRunCreated),


### PR DESCRIPTION
# Pull Request: Fix Typo in AssistantStreamEvent Variant

## Summary

This PR fixes a typo in the `AssistantStreamEvent` enum:  
Renames `TreadCreated` to `ThreadCreated` for better consistency and readability.

---

## Changes

- **Enum Variant Renamed**  
  - Before: `TreadCreated(ThreadObject)`
  - After:  `ThreadCreated(ThreadObject)`

- **Event Handling Updated**  
  - The match arm for the `"thread.created"` event now uses `AssistantStreamEvent::ThreadCreated` instead of the misspelled variant.

---

## Motivation

- **Consistency & Readability**  
  The previous variant name `TreadCreated` was a typo and did not match the intended naming convention. This change ensures the code is self-explanatory and maintains consistent terminology.
- **Maintainability**  
  Fixing typos in public APIs and enums helps prevent confusion and potential bugs in the future.

---

## Impact

- All usages of `AssistantStreamEvent::TreadCreated` should be updated to `AssistantStreamEvent::ThreadCreated`.
- No functional changes were made; this is strictly a naming correction.

---

## Reference

```diff
-    TreadCreated(ThreadObject),
+    ThreadCreated(ThreadObject),