### PR TITLE
Add default value for some response struct

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -951,8 +951,13 @@ pub struct CreateChatCompletionResponse {
     pub system_fingerprint: Option<String>,
 
     /// The object type, which is always `chat.completion`.
+    #[serde(default="object_default_value")]
     pub object: String,
     pub usage: Option<CompletionUsage>,
+}
+
+pub fn object_default_value()->String{
+    "chat.completion".to_string()
 }
 
 /// Parsed server side events stream until an \[DONE\] is received from server.

--- a/async-openai/src/types/completion.rs
+++ b/async-openai/src/types/completion.rs
@@ -132,8 +132,13 @@ pub struct CreateCompletionResponse {
     pub system_fingerprint: Option<String>,
 
     /// The object type, which is always "text_completion"
+    #[serde(default="object_default_value")]
     pub object: String,
     pub usage: Option<CompletionUsage>,
+}
+
+pub fn object_default_value()->String{
+    "text_completion".to_string()
 }
 
 /// Parsed server side events stream until an \[DONE\] is received from server.

--- a/examples/gemini-openai-compatibility/src/gemini_types.rs
+++ b/examples/gemini-openai-compatibility/src/gemini_types.rs
@@ -55,9 +55,14 @@ pub struct GeminiCreateChatCompletionResponse {
     /// The model used for the chat completion.
     pub model: String,
     /// The object type, which is always `chat.completion`.
+    #[serde(default="object_default_value")]
     pub object: String,
     /// usage statistics for the entire request.
     pub usage: Option<CompletionUsage>,
+}
+
+pub fn object_default_value()->String{
+    "chat.completion".to_string()
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]


### PR DESCRIPTION
Some OpenAI Compatible providers return completions without object field which causes the error. So add default value for CreateChatCompletionResponse, CreateCompletionResponse,GeminiCreateChatCompletionResponse.