### PR TITLE
Update CreateChatCompletionResponse to have optional id field

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -936,7 +936,7 @@ pub struct ChatChoice {
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
 pub struct CreateChatCompletionResponse {
     /// A unique identifier for the chat completion.
-    pub id: String,
+    pub id: Option<String>,
     /// A list of chat completion choices. Can be more than one if `n` is greater than 1.
     pub choices: Vec<ChatChoice>,
     /// The Unix timestamp (in seconds) of when the chat completion was created.

--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -1020,7 +1020,7 @@ pub struct ChatChoiceStream {
 /// Represents a streamed chunk of a chat completion response returned by model, based on the provided input.
 pub struct CreateChatCompletionStreamResponse {
     /// A unique identifier for the chat completion. Each chunk has the same ID.
-    pub id: String,
+    pub id: Option<String>,
     /// A list of chat completion choices. Can contain more than one elements if `n` is greater than 1. Can also be empty for the last chunk if you set `stream_options: {"include_usage": true}`.
     pub choices: Vec<ChatChoiceStream>,
 


### PR DESCRIPTION
Currently implementing OpenVINO Model Server as LLM Provider
the stream response is without id field e.g. the structure as following
```
{
  "choices": [
    {
      "delta": {
        "content": 
      },
      "finish_reason":
      "index": 
      "logprobs":
    }
  ],
  "created": 
  "model":
  "object": "chat.completion.chunk"
}
```

Hence, proposing this change