### PR TITLE
Add ReasoningEffort::Minimal

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -620,6 +620,7 @@ pub enum ServiceTierResponse {
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum ReasoningEffort {
+    Minimal,
     Low,
     Medium,
     High,


### PR DESCRIPTION
The Minimal enum value for ReasoningEffort is added. The newest gpt-5 model supports this value for reasoning_effort. [Docs](https://platform.openai.com/docs/api-reference/chat/create#chat_create-reasoning_effort)