### PR TITLE
feat: Respect backoff policy for streaming

### DIFF
--- a/async-openai/src/lib.rs
+++ b/async-openai/src/lib.rs
@@ -165,6 +165,7 @@ mod projects;
 mod responses;
 mod runs;
 mod steps;
+mod streaming_backoff;
 mod threads;
 pub mod traits;
 pub mod types;

--- a/async-openai/src/streaming_backoff.rs
+++ b/async-openai/src/streaming_backoff.rs
@@ -1,0 +1,64 @@
+use std::time::Duration;
+
+use reqwest::StatusCode;
+use reqwest_eventsource::retry::RetryPolicy;
+
+/// Wraps `backoff::ExponentialBackoff` to provide a custom backoff suitable for
+/// reqwest_eventsource
+pub struct StreamingBackoff(backoff::ExponentialBackoff);
+
+impl StreamingBackoff {
+    fn should_retry(&self, error: &reqwest_eventsource::Error) -> bool {
+        // Errors at the connection level only
+        if let reqwest_eventsource::Error::Transport(error) = error {
+            // TODO: We can't inspect the response body as reading consumes it.
+            // This is problematic because quota exceeded errors are also 429.
+            return error
+                .status()
+                .as_ref()
+                .is_some_and(StatusCode::is_server_error)
+                || error.status() == Some(reqwest::StatusCode::TOO_MANY_REQUESTS);
+        }
+
+        true
+    }
+}
+
+impl From<backoff::ExponentialBackoff> for StreamingBackoff {
+    fn from(backoff: backoff::ExponentialBackoff) -> Self {
+        Self(backoff)
+    }
+}
+
+impl RetryPolicy for StreamingBackoff {
+    fn retry(
+        &self,
+        error: &reqwest_eventsource::Error,
+        last_retry: Option<(usize, Duration)>,
+    ) -> Option<Duration> {
+        if !self.should_retry(error) {
+            return None;
+        };
+
+        // Ignoring backoff randomization factor for simplicity
+        // Basically reimplements the retry policy from eventsource
+        if let Some((_retry_num, last_duration)) = last_retry {
+            let duration = last_duration.mul_f64(self.0.multiplier);
+
+            if let Some(max_duration) = self.0.max_elapsed_time {
+                Some(duration.min(max_duration))
+            } else {
+                Some(duration)
+            }
+        } else {
+            Some(self.0.initial_interval)
+        }
+    }
+
+    fn set_reconnection_time(&mut self, duration: Duration) {
+        self.0.initial_interval = duration;
+        if let Some(max_elapsed_time) = self.0.max_elapsed_time {
+            self.0.max_elapsed_time = Some(max_elapsed_time.max(duration))
+        }
+    }
+}


### PR DESCRIPTION
Went into the rabbit hole of streaming backoffs. Turns out eventsource has something already, of which I'm not 100% certain how well it works, but since streaming is a bit different, we want to generally retry all the time. This PR sets the event source retry policy to the (similar) values of backoff. There's one slight difference in behaviour, in that on transport errors, we only retry server errors or 429s, like with regular requests.

We can't inspect the response body at this point, so we can't differentiate between rate limits and quota errors (thanks openai).

Also, during streaming, token errors are a rough 400. I think maybe. Sometimes.

Practically, I'm trying to stream a lot of agents in parallel, hoping with this I can mitigate it somewhat.