### PR TITLE
add Scale and Priority to ServiceTier

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -607,6 +607,8 @@ pub enum ServiceTier {
     Auto,
     Default,
     Flex,
+    Scale,
+    Priority,
 }
 
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq)]
@@ -615,6 +617,7 @@ pub enum ServiceTierResponse {
     Scale,
     Default,
     Flex,
+    Priority,
 }
 
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq)]


### PR DESCRIPTION
The new [3.1.0 spec](https://app.stainless.com/api/spec/documented/openai/openapi.documented.yml) added variants to the ServiceTier

```yaml
        ServiceTier:
            type: string
            description: |
                Specifies the processing type used for serving the request.
                  - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
                  - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.
                  - If set to '[flex](https://platform.openai.com/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.
                  - When not set, the default behavior is 'auto'.

                  When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
            enum:
                - auto
                - default
                - flex
                - scale
                - priority
            nullable: true
            default: auto
```