### PR TITLE
fix: Add Scale and Priority to the `ServiceTier` enum for the Responses API

### DIFF
--- a/async-openai/src/types/responses.rs
+++ b/async-openai/src/types/responses.rs
@@ -329,6 +329,8 @@ pub enum ServiceTier {
     Auto,
     Default,
     Flex,
+    Scale,
+    Priority,
 }
 
 /// Truncation strategies.


### PR DESCRIPTION
## Description
- This PR adds the Scale and Priority variants to the ServiceTier enum, similar to #416 
- However, #416 did so only for the Chat Completions API. This PR adds these variants for the Responses API.