### PR TITLE
Fix schema of code interpreter call output

### DIFF
--- a/async-openai/src/types/responses.rs
+++ b/async-openai/src/types/responses.rs
@@ -1183,15 +1183,17 @@ pub struct ImageGenerationCallOutput {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CodeInterpreterCallOutput {
     /// The code that was executed.
-    pub code: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
     /// Unique ID of the call.
     pub id: String,
     /// Status of the tool call.
     pub status: String,
     /// ID of the container used to run the code.
     pub container_id: String,
-    /// The results of the execution: logs or files.
-    pub results: Vec<CodeInterpreterResult>,
+    /// The outputs of the execution: logs or files.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outputs: Option<Vec<CodeInterpreterResult>>,
 }
 
 /// Individual result from a code interpreter: either logs or files.


### PR DESCRIPTION
## Description
- Fixes the schema of code interpreter call output to align with OpenAI's documentation

**OpenAI's Specified Schema**
<img width="1338" height="1134" alt="image" src="https://github.com/user-attachments/assets/d23c8c18-f78e-4e2b-8f27-0b4cb156ffb2" />
