### PR TITLE
fix: Update `OutputItem` to align with OpenAI's Specification

### DIFF
--- a/async-openai/src/types/responses.rs
+++ b/async-openai/src/types/responses.rs
@@ -2104,20 +2104,34 @@ pub struct ResponseMetadata {
 
 /// Output item
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
 #[non_exhaustive]
-pub struct OutputItem {
-    pub id: String,
+pub enum OutputItem {
+    Message(OutputMessage),
+    FileSearchCall(FileSearchCallOutput),
+    FunctionCall(FunctionCall),
+    WebSearchCall(WebSearchCallOutput),
+    ComputerCall(ComputerCallOutput),
+    Reasoning(ReasoningItem),
+    ImageGenerationCall(ImageGenerationCallOutput),
+    CodeInterpreterCall(CodeInterpreterCallOutput),
+    LocalShellCall(LocalShellCallOutput),
+    McpCall(McpCallOutput),
+    McpListTools(McpListToolsOutput),
+    McpApprovalRequest(McpApprovalRequestOutput),
+    CustomToolCall(CustomToolCallOutput),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct CustomToolCallOutput {
+    pub call_id: String,
+    pub input: String,
+    pub name: String,
     #[serde(rename = "type")]
-    pub item_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Vec<ContentPart>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub role: Option<String>,
-    /// For reasoning items - summary paragraphs
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub summary: Option<Vec<serde_json::Value>>,
+    pub output_type: String,
+    pub id: String,
 }
 
 /// Content part

--- a/async-openai/src/types/responses.rs
+++ b/async-openai/src/types/responses.rs
@@ -2129,8 +2129,6 @@ pub struct CustomToolCallOutput {
     pub call_id: String,
     pub input: String,
     pub name: String,
-    #[serde(rename = "type")]
-    pub output_type: String,
     pub id: String,
 }
 


### PR DESCRIPTION
## Description
- According to OpenAI's [specification](https://platform.openai.com/docs/api-reference/responses/object#responses/object-output), `OutputItem` should be a tagged union. This PR updates that struct to align with OpenAI's specification
- A nice benefit of this is that streaming with tool calls is now supported