### PR TITLE
fix: CompoundFilter should use CompoundType instead

### DIFF
--- a/async-openai/src/types/responses.rs
+++ b/async-openai/src/types/responses.rs
@@ -540,7 +540,7 @@ pub enum ComparisonType {
 pub struct CompoundFilter {
     /// Type of operation
     #[serde(rename = "type")]
-    pub op: ComparisonType,
+    pub op: CompoundType,
     /// Array of filters to combine. Items can be ComparisonFilter or CompoundFilter.
     pub filters: Vec<Filter>,
 }


### PR DESCRIPTION
The response filters had a typo/mistake where the wrong comparison type is used in a compound filter.

We want options like AND or OR not Equals, NEquals etc.

https://platform.openai.com/docs/api-reference/responses/create

<img width="682" height="1197" alt="Screenshot 2025-09-02 at 19 12 36" src="https://github.com/user-attachments/assets/33feed6a-ad3a-4193-8e70-96fede214e01" />
