### PR TITLE
feat(error): enhance `OpenAIError::StreamError` payload

### DIFF
--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -485,7 +485,7 @@ where
         while let Some(ev) = event_source.next().await {
             match ev {
                 Err(e) => {
-                    if let Err(_e) = tx.send(Err(OpenAIError::StreamError(e.to_string()))) {
+                    if let Err(_e) = tx.send(Err(OpenAIError::StreamError(e.into()))) {
                         // rx dropped
                         break;
                     }
@@ -530,7 +530,7 @@ where
         while let Some(ev) = event_source.next().await {
             match ev {
                 Err(e) => {
-                    if let Err(_e) = tx.send(Err(OpenAIError::StreamError(e.to_string()))) {
+                    if let Err(_e) = tx.send(Err(OpenAIError::StreamError(e.into()))) {
                         // rx dropped
                         break;
                     }

--- a/async-openai/src/error.rs
+++ b/async-openai/src/error.rs
@@ -20,7 +20,7 @@ pub enum OpenAIError {
     FileReadError(String),
     /// Error on SSE streaming
     #[error("stream failed: {0}")]
-    StreamError(String),
+    StreamError(StreamError),
     /// Error from client side validation
     /// or when builder fails to build request before making API call
     #[error("invalid args: {0}")]
@@ -59,6 +59,16 @@ impl std::fmt::Display for ApiError {
 
         write!(f, "{}", parts.join(" "))
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum StreamError {
+    /// Underlying error from reqwest_eventsource library when reading the stream
+    #[error("{0}")]
+    ReqwestEventSource(#[from] reqwest_eventsource::Error),
+    /// Error when a stream event does not match one of the expected values
+    #[error("Unrecognized event: {0:#?}")]
+    UnrecognizedEvent(eventsource_stream::Event),
 }
 
 /// Wrapper to deserialize the error object nested in "error" JSON key

--- a/async-openai/src/types/assistant_stream.rs
+++ b/async-openai/src/types/assistant_stream.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use futures::Stream;
 use serde::Deserialize;
 
-use crate::error::{map_deserialization_error, ApiError, OpenAIError};
+use crate::error::{map_deserialization_error, ApiError, OpenAIError, StreamError};
 
 use super::{
     MessageDeltaObject, MessageObject, RunObject, RunStepDeltaObject, RunStepObject, ThreadObject,
@@ -208,7 +208,7 @@ impl TryFrom<eventsource_stream::Event> for AssistantStreamEvent {
             "done" => Ok(AssistantStreamEvent::Done(value.data)),
 
             _ => Err(OpenAIError::StreamError(
-                "Unrecognized event: {value:?#}".into(),
+                StreamError::UnrecognizedEvent(value),
             )),
         }
     }


### PR DESCRIPTION
- Introduces enum `StreamError`
- Replace `OpenAIError::StreamError` payload from `String` to `StreamError`

This is technically a breaking change as it can break codes that `match`ed the `OpenAIError::StreamError` variant. 
At least the `Display` string should look the same.

Closes #434