### PR TITLE
feat(spec): Add `name` field to `ResponseFunctionCallArgumentsDone`

### DIFF
--- a/async-openai/src/types/responses.rs
+++ b/async-openai/src/types/responses.rs
@@ -1753,6 +1753,7 @@ pub struct ResponseFunctionCallArgumentsDelta {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct ResponseFunctionCallArgumentsDone {
+    pub name: String,
     pub sequence_number: u64,
     pub item_id: String,
     pub output_index: u32,


### PR DESCRIPTION
Added a name field to the ResponseFunctionCallArgumentsDone struct. Its crucial  to identify the tool OpenAI instructed to execute, allowing users to filter and select the appropriate tool for execution. This change also syncs to OpenAI specs.