### PR TITLE
Add support for expires_after field in CreateFileRequest and expires_at field in OpenAIFile

### DIFF
--- a/async-openai/src/file.rs
+++ b/async-openai/src/file.rs
@@ -70,7 +70,7 @@ impl<'c, C: Config> Files<'c, C> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        types::{CreateFileRequestArgs, FilePurpose},
+        types::{CreateFileRequestArgs, FilePurpose, FileExpiresAfter, FileExpiresAfterAnchor},
         Client,
     };
 
@@ -89,6 +89,7 @@ mod tests {
         let request = CreateFileRequestArgs::default()
             .file(test_file_path)
             .purpose(FilePurpose::FineTune)
+            .expires_after(FileExpiresAfter{ anchor: FileExpiresAfterAnchor::CreatedAt, seconds: 3600 })
             .build()
             .unwrap();
 
@@ -111,6 +112,7 @@ mod tests {
         assert_eq!(openai_file.bytes, retrieved_file.bytes);
         assert_eq!(openai_file.filename, retrieved_file.filename);
         assert_eq!(openai_file.purpose, retrieved_file.purpose);
+        assert_eq!(openai_file.expires_at, retrieved_file.expires_at);
 
         /*
         // "To help mitigate abuse, downloading of fine-tune training files is disabled for free accounts."

--- a/async-openai/src/types/file.rs
+++ b/async-openai/src/types/file.rs
@@ -51,7 +51,7 @@ pub struct CreateFileRequest {
     pub purpose: FilePurpose,
 
     /// The expiration policy for a file. By default, files with `purpose=batch` expire after 30 days and all other files are persisted until they are manually deleted.
-    pub expires_after: FileExpiresAfter,
+    pub expires_after: Option<FileExpiresAfter>,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]

--- a/async-openai/src/types/impls.rs
+++ b/async-openai/src/types/impls.rs
@@ -982,11 +982,14 @@ impl AsyncTryFrom<CreateFileRequest> for reqwest::multipart::Form {
 
     async fn try_from(request: CreateFileRequest) -> Result<Self, Self::Error> {
         let file_part = create_file_part(request.file.source).await?;
-        let form = reqwest::multipart::Form::new()
+        let mut form = reqwest::multipart::Form::new()
             .part("file", file_part)
-            .text("purpose", request.purpose.to_string())
-            .text("expires_after[anchor]", request.expires_after.anchor.to_string())
-            .text("expires_after[seconds]", request.expires_after.seconds.to_string());
+            .text("purpose", request.purpose.to_string());
+        
+        if let Some(expires_after) = request.expires_after {
+            form = form.text("expires_after[anchor]", expires_after.anchor.to_string())
+                .text("expires_after[seconds]", expires_after.seconds.to_string());
+        }
         Ok(form)
     }
 }

--- a/async-openai/src/vector_store_files.rs
+++ b/async-openai/src/vector_store_files.rs
@@ -113,6 +113,7 @@ mod tests {
                     String::from(":3").into_bytes(),
                 ),
                 purpose: FilePurpose::Assistants,
+                expires_after: None,
             })
             .await?;
 


### PR DESCRIPTION
- The `expires_after: Option<FileExpiresAfter>` field is added to `CreateFileRequest`. This new field is added to the `post https://api.openai.com/v1/files` request when defined.
  - https://platform.openai.com/docs/api-reference/files
  - I tried to follow the patterns of other fields by adding the `FileExpiresAfterAnchor` enum, even though it only contains one option, `CreatedAt`.
- The `expires_at: Option<u32>` field is added to OpenAIFile. 
  - https://platform.openai.com/docs/api-reference/files/object
  - I found that `expires_at` can be `null` if you didn't specify `expires_after` in the request, even though the OpenAI documentation does not describe it as being optional. That is why I made the type `Option<u32>`, not `u32`.