### PR TITLE
String errors

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -25,6 +25,8 @@ native-tls-vendored = ["reqwest/native-tls-vendored"]
 realtime = ["dep:tokio-tungstenite"]
 # Bring your own types
 byot = []
+# Deserialize error responses yourself
+string-errors = []
 
 [dependencies]
 async-openai-macros = { path = "../async-openai-macros", version = "0.1.0" }
@@ -58,6 +60,10 @@ serde_json = "1.0"
 [[test]]
 name = "bring-your-own-type"
 required-features = ["byot"]
+
+[[test]]
+name = "string-errors"
+required-features = ["string-errors", "byot"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/async-openai/README.md
+++ b/async-openai/README.md
@@ -145,6 +145,13 @@ This can be useful in many scenarios:
 Visit [examples/bring-your-own-type](https://github.com/64bit/async-openai/tree/main/examples/bring-your-own-type)
 directory to learn more.
 
+## String Errors
+
+Enable the `string-errors` feature to receive API errors as raw strings instead of parsed structs. This can be useful
+in scenarios where providers expose errors in different formats.
+
+See [examples/string-errors](https://github.com/64bit/async-openai/tree/main/examples/string-errors) for usage.
+
 ## Dynamic Dispatch for Different Providers
 
 For any struct that implements `Config` trait, you can wrap it in a smart pointer and cast the pointer to `dyn Config`

--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -523,7 +523,7 @@ async fn read_response(response: Response) -> Result<Bytes, OpenAIError> {
         #[cfg(feature = "string-errors")]
         {
             let message: String = String::from_utf8_lossy(&bytes).into_owned();
-            return Err(OpenAIError::ApiError(message));
+            return Err(OpenAIError::ApiError(crate::error::RawApiError(message)));
         }
     }
 

--- a/async-openai/src/error.rs
+++ b/async-openai/src/error.rs
@@ -2,6 +2,28 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Raw API error string from providers with custom error formats
+///
+/// Only available with the `string-errors` feature.
+#[cfg(feature = "string-errors")]
+#[derive(Debug, Clone)]
+pub struct RawApiError(pub String);
+
+#[cfg(feature = "string-errors")]
+impl std::fmt::Display for RawApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(feature = "string-errors")]
+impl RawApiError {
+    /// Parse the raw error string into a custom type
+    pub fn parse<T: serde::de::DeserializeOwned>(&self) -> Result<T, serde_json::Error> {
+        serde_json::from_str(&self.0)
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum OpenAIError {
     /// Underlying error from reqwest library after an API call was made
@@ -15,7 +37,7 @@ pub enum OpenAIError {
     /// This feature leaves deserialization to the user, not even assuming json.
     #[cfg(feature = "string-errors")]
     #[error("{0}")]
-    ApiError(String),
+    ApiError(RawApiError),
     /// Error when a response cannot be deserialized into a Rust type
     #[error("failed to deserialize api response: error:{0} content:{1}")]
     JSONDeserialize(serde_json::Error, String),

--- a/async-openai/src/error.rs
+++ b/async-openai/src/error.rs
@@ -8,8 +8,14 @@ pub enum OpenAIError {
     #[error("http error: {0}")]
     Reqwest(#[from] reqwest::Error),
     /// OpenAI returns error object with details of API call failure
+    #[cfg(not(feature = "string-errors"))]
     #[error("{0}")]
     ApiError(ApiError),
+    /// Some OpenAI compatible services return error messages in diverge in error formats.
+    /// This feature leaves deserialization to the user, not even assuming json.
+    #[cfg(feature = "string-errors")]
+    #[error("{0}")]
+    ApiError(String),
     /// Error when a response cannot be deserialized into a Rust type
     #[error("failed to deserialize api response: error:{0} content:{1}")]
     JSONDeserialize(serde_json::Error, String),

--- a/async-openai/tests/string-errors.rs
+++ b/async-openai/tests/string-errors.rs
@@ -12,8 +12,8 @@ async fn test_byot_errors() {
     let _r: Result<Value, OpenAIError> = client.chat().create_byot(json!({})).await;
 
     match _r.unwrap_err() {
-        OpenAIError::ApiError(value) => {
-            let _value = serde_json::from_str::<Value>(&value).unwrap();
+        OpenAIError::ApiError(raw_error) => {
+            let _value: Value = raw_error.parse().unwrap();
         }
         _ => {}
     };

--- a/async-openai/tests/string-errors.rs
+++ b/async-openai/tests/string-errors.rs
@@ -1,0 +1,20 @@
+#![allow(dead_code)]
+//! The purpose of this test to make sure that with the string-errors feature enabled, the error is returned as a string.
+//! Enabling the byot feature allows for a simpler test, as the body can be written as an empty json value.
+
+use async_openai::{error::OpenAIError, Client};
+use serde_json::{json, Value};
+
+#[tokio::test]
+async fn test_byot_errors() {
+    let client = Client::new();
+
+    let _r: Result<Value, OpenAIError> = client.chat().create_byot(json!({})).await;
+
+    match _r.unwrap_err() {
+        OpenAIError::ApiError(value) => {
+            let _value = serde_json::from_str::<Value>(&value).unwrap();
+        }
+        _ => {}
+    };
+}

--- a/examples/string-errors/Cargo.toml
+++ b/examples/string-errors/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "string-errors"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+async-openai = { path = "../../async-openai", features = ["string-errors", "byot"] }
+tokio = { version = "1.43.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/examples/string-errors/README.md
+++ b/examples/string-errors/README.md
@@ -1,0 +1,3 @@
+# String Errors Example
+
+This example demonstrates how to use the `string-errors` feature to handle API errors from providers that use different error formats than OpenAI.

--- a/examples/string-errors/src/main.rs
+++ b/examples/string-errors/src/main.rs
@@ -30,8 +30,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await;
 
     match result.unwrap_err() {
-        OpenAIError::ApiError(error_string) => {
-            let error = serde_json::from_str::<ErrorWrapper>(&error_string).unwrap();
+        OpenAIError::ApiError(raw_error) => {
+            let error: ErrorWrapper = raw_error.parse().unwrap();
             println!("Code: {}", error.error.code);
             println!("Message: {}", error.error.message);
         }

--- a/examples/string-errors/src/main.rs
+++ b/examples/string-errors/src/main.rs
@@ -1,0 +1,42 @@
+//! This example demonstrates how errors from OpenRouter can be parsed by the library consumer.
+//! It uses the `string-errors` feature to receive API errors as raw strings instead of parsed structs.
+
+use async_openai::{config::OpenAIConfig, error::OpenAIError, Client};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct OpenRouterError {
+    code: i32,
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorWrapper {
+    error: OpenRouterError,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = OpenAIConfig::new().with_api_base("https://openrouter.ai/api/v1");
+    let client = Client::with_config(config);
+
+    let result: Result<serde_json::Value, OpenAIError> = client
+        .chat()
+        .create_byot(json!({
+            "model": "invalid-model",
+            "messages": [{"role": "user", "content": "Hello"}]
+        }))
+        .await;
+
+    match result.unwrap_err() {
+        OpenAIError::ApiError(error_string) => {
+            let error = serde_json::from_str::<ErrorWrapper>(&error_string).unwrap();
+            println!("Code: {}", error.error.code);
+            println!("Message: {}", error.error.message);
+        }
+        _ => panic!("Expected OpenAIError::ApiError"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
References #448 

In the issue, the idea of exposing a `serde_json::Value` was discussed. In some internal server error cases, even `OpenAI` does return error messages that are not json. This made me wonder if representing the error as `String` might give users more flexibility. Would be eager to get some feedback if this matches what you had in mind @64bit 

I'm uncertain if the second commit (offering a helper method to parse the raw string into a type) provides value / goes beyond the scope of this library, happy to remove it.