### PR TITLE
fix: groq service_tier is OnDemand

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -618,6 +618,8 @@ pub enum ServiceTier {
     Flex,
     Scale,
     Priority,
+    #[serde(rename = "on_demand")]
+    OnDemand,
 }
 
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq)]
@@ -627,6 +629,8 @@ pub enum ServiceTierResponse {
     Default,
     Flex,
     Priority,
+    #[serde(rename = "on_demand")]
+    OnDemand,
 }
 
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq)]

--- a/async-openai/src/types/responses.rs
+++ b/async-openai/src/types/responses.rs
@@ -334,6 +334,9 @@ pub enum ServiceTier {
     Flex,
     Scale,
     Priority,
+
+    #[serde(rename = "on_demand")]
+    OnDemand,
 }
 
 /// Truncation strategies.


### PR DESCRIPTION
got async-openai deserialization errors for groq on free tier. 


```
ERROR async_openai::error: failed deserialization of: {"id":"chat04-db87f6e7f5e7","object":"chat.comple
   tion","created":1761988004,"model":"moonshotai/kimi-k2-instruct-0905","choices":[{"index":0,"message":{"role":"assistant","content":"```mermaid   K\n```"},"logprobs":null,"finish_reason":"stop"}],"usage":{"queue_time":0.243496693,"prompt_tokens":368,"prompt_time":0.046633806,"completion_tokens":268,"completion_time":0.492293986,"total_tokens":636,"total_time":0.538927792},"usage_breakdown":null,"system_fingerprint":"fp","x_groq":{"id":"req_zapj1rejb9pdn"},"service_tier":"on_demand"}

```