### PR TITLE
Add ReasoningEffort::None

### DIFF
--- a/async-openai/src/types/chat/chat_types.rs
+++ b/async-openai/src/types/chat/chat_types.rs
@@ -771,9 +771,14 @@ pub enum ServiceTier {
     Priority,
 }
 
+/// Constrains effort on reasoning for reasoning models. Currently supported values are none, minimal, low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+/// - gpt-5.1 defaults to none, which does not perform reasoning. The supported reasoning values for gpt-5.1 are none, low, medium, and high. Tool calls are supported for all reasoning values in gpt-5.1.
+/// - All models before gpt-5.1 default to medium reasoning effort, and do not support none.
+/// - The gpt-5-pro model defaults to (and only supports) high reasoning effort.
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum ReasoningEffort {
+    None,
     Minimal,
     Low,
     #[default]


### PR DESCRIPTION
[Here is the docs.](https://platform.openai.com/docs/api-reference/responses/create#responses_create-reasoning) I tested it on my own project.