### PR TITLE
feat: configurable per request path

### DIFF
--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -204,9 +204,14 @@ impl<C: Config> Client<C> {
         path: &str,
         request_options: &RequestOptions,
     ) -> reqwest::RequestBuilder {
-        let mut request_builder = self
-            .http_client
-            .request(method, self.config.url(path))
+        let mut request_builder = if let Some(path) = request_options.path() {
+            self.http_client
+                .request(method, self.config.url(path.as_str()))
+        } else {
+            self.http_client.request(method, self.config.url(path))
+        };
+
+        request_builder = request_builder
             .query(&self.config.query())
             .headers(self.config.headers());
 

--- a/async-openai/src/request_options.rs
+++ b/async-openai/src/request_options.rs
@@ -8,6 +8,7 @@ use crate::{config::OPENAI_API_BASE, error::OpenAIError};
 pub struct RequestOptions {
     query: Option<Vec<(String, String)>>,
     headers: Option<HeaderMap>,
+    path: Option<String>,
 }
 
 impl RequestOptions {
@@ -15,7 +16,18 @@ impl RequestOptions {
         Self {
             query: None,
             headers: None,
+            path: None,
         }
+    }
+
+    pub(crate) fn with_path(&mut self, path: &str) -> Result<(), OpenAIError> {
+        if path.is_empty() {
+            return Err(OpenAIError::InvalidArgument(
+                "Path cannot be empty".to_string(),
+            ));
+        }
+        self.path = Some(path.to_string());
+        Ok(())
     }
 
     pub(crate) fn with_headers(&mut self, headers: HeaderMap) {
@@ -80,5 +92,9 @@ impl RequestOptions {
 
     pub(crate) fn headers(&self) -> Option<&HeaderMap> {
         self.headers.as_ref()
+    }
+
+    pub(crate) fn path(&self) -> Option<&String> {
+        self.path.as_ref()
     }
 }

--- a/async-openai/src/traits.rs
+++ b/async-openai/src/traits.rs
@@ -53,4 +53,10 @@ pub trait RequestOptionsBuilder: Sized {
         self.options_mut().with_query(query)?;
         Ok(self)
     }
+
+    /// Add a path to RequestOptions
+    fn path<P: Into<String>>(mut self, path: P) -> Result<Self, OpenAIError> {
+        self.options_mut().with_path(path.into().as_str())?;
+        Ok(self)
+    }
 }


### PR DESCRIPTION
Allow modifying per request path instead of hard coded values. 

For example:
```
client
  .chat()
  .path("/messages")?
  .create(request)
  .await?
```

This is to support use cases like https://github.com/64bit/async-openai/pull/369