### PR TITLE
Handling non-OpenAI APIs

### DIFF
--- a/async-openai/src/types/responses/response.rs
+++ b/async-openai/src/types/responses/response.rs
@@ -2350,35 +2350,6 @@ pub struct MCPApprovalRequest {
     pub server_label: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
-pub struct InputTokenDetails {
-    /// The number of tokens that were retrieved from the cache.
-    /// [More on prompt caching](https://platform.openai.com/docs/guides/prompt-caching).
-    pub cached_tokens: u32,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
-pub struct OutputTokenDetails {
-    /// The number of reasoning tokens.
-    pub reasoning_tokens: u32,
-}
-
-/// Usage statistics for a response.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
-#[serde(default)]
-pub struct ResponseUsage {
-    /// The number of input tokens.
-    pub input_tokens: u32,
-    /// A detailed breakdown of the input tokens.
-    pub input_tokens_details: InputTokenDetails,
-    /// The number of output tokens.
-    pub output_tokens: u32,
-    /// A detailed breakdown of the output tokens.
-    pub output_tokens_details: OutputTokenDetails,
-    /// The total number of tokens used.
-    pub total_tokens: u32,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Instructions {

--- a/async-openai/src/types/shared/response_usage.rs
+++ b/async-openai/src/types/shared/response_usage.rs
@@ -1,20 +1,21 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 pub struct InputTokenDetails {
     /// The number of tokens that were retrieved from the cache.
     /// [More on prompt caching](https://platform.openai.com/docs/guides/prompt-caching).
     pub cached_tokens: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 pub struct OutputTokenDetails {
     /// The number of reasoning tokens.
     pub reasoning_tokens: u32,
 }
 
 /// Usage statistics for a response.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
+#[serde(default)]
 pub struct ResponseUsage {
     /// The number of input tokens.
     pub input_tokens: u32,


### PR DESCRIPTION
Non-OpenAI APIs that implement a similar interface don't always include the `output[].content[].annotations` JSON path. Specifically, I ran into this issue with [LM Studio](https://lmstudio.ai/docs/developer/openai-compat/responses), which doesn't include that attribute. 

This pull request makes a minor change to the `OutputTextContent` struct in `async-openai/src/types/responses/response.rs`. The change ensures that the `annotations` field will now default to an empty vector if it is missing during deserialization, which improves robustness when handling API responses for non-OpenAI APIs.