### PR TITLE
fix: remove duplicate doc comments in byot macro output

### DIFF
--- a/async-openai-macros/src/lib.rs
+++ b/async-openai-macros/src/lib.rs
@@ -130,7 +130,6 @@ pub fn byot(args: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let expanded = quote! {
-        #(#attrs)*
         #input
 
         #(#attrs)*


### PR DESCRIPTION
Fix duplicate doc comments generated by the byot macro. The macro was outputting #(#attrs)* twice. Fixes #345