### PR TITLE
chore: update to reqwest 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ resolver = "2"
 
 [workspace.package]
 rust-version = "1.75"
+
+[patch.crates-io]
+reqwest-eventsource = { git = "https://github.com/ttys3/reqwest-eventsource.git" }

--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -15,9 +15,9 @@ repository = "https://github.com/64bit/async-openai"
 [features]
 default = ["rustls"]
 # Enable rustls for TLS support
-rustls = ["dep:reqwest", "reqwest/rustls-tls-native-roots"]
+rustls = ["dep:reqwest", "reqwest/rustls-native-certs"]
 # Enable rustls and webpki-roots
-rustls-webpki-roots = ["dep:reqwest", "reqwest/rustls-tls-webpki-roots"]
+rustls-webpki-roots = ["dep:reqwest", "reqwest/webpki-roots"]
 # Enable native-tls for TLS support
 native-tls = ["dep:reqwest", "reqwest/native-tls"]
 # Remove dependency on OpenSSL
@@ -162,10 +162,11 @@ bytes = { version = "1.11", optional = true }
 async-openai-macros = { path = "../async-openai-macros", version = "0.1.1", optional = true }
 base64 = { version = "0.22", optional = true }
 rand = { version = "0.9", optional = true }
-reqwest = { version = "0.12", features = [
+reqwest = { version = "0.13", features = [
   "json",
   "stream",
   "multipart",
+  "query",
 ], default-features = false, optional = true }
 thiserror = { version = "2", optional = true }
 tracing = { version = "0.1", optional = true }
@@ -184,7 +185,7 @@ futures = { version = "0.3", optional = true }
 tokio = { version = "1", features = ["fs", "macros"], optional = true }
 tokio-stream = { version = "0.1", optional = true }
 tokio-util = { version = "0.7", features = ["codec", "io-util"], optional = true }
-reqwest-eventsource = { version = "0.6.0", optional = true }
+reqwest-eventsource = { git = "https://github.com/ttys3/reqwest-eventsource.git", branch = "main", optional = true }
 eventsource-stream = { version = "0.2", optional = true }
 ## For Realtime websocket
 tokio-tungstenite = { version = "0.28", optional = true, default-features = false }


### PR DESCRIPTION
since this crate depends on reqwest-eventsource

we still need to wait reqwest-eventsource upgrade to reqwest 0.13

see https://github.com/jpopesculian/reqwest-eventsource/pull/35