### PR TITLE
Allow missing id in ReasoningItem

### DIFF
--- a/async-openai/src/types/responses/response.rs
+++ b/async-openai/src/types/responses/response.rs
@@ -1829,7 +1829,7 @@ pub struct ReasoningTextContent {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ReasoningItem {
     /// Unique identifier of the reasoning content.
-    pub id: String,
+    pub id: Option<String>,
     /// Reasoning summary content.
     pub summary: Vec<SummaryPart>,
     /// Reasoning text content.


### PR DESCRIPTION
While this is a required field in the OpenAPI spec, the spec is wrong; OpenAI itself accepts a missing `id` and popular tools like OpenCode and Codex send requests without an `id`. This aligns the behavior with the real world usage to allow deserializing OpenCode/Codex (and other) requests