### PR TITLE
chore: upgrade reqwest to 0.13 and remove reqwest-eventsource

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -14,10 +14,8 @@ repository = "https://github.com/64bit/async-openai"
 
 [features]
 default = ["rustls"]
-# Enable rustls for TLS support
-rustls = ["dep:reqwest", "reqwest/rustls-tls-native-roots"]
-# Enable rustls and webpki-roots
-rustls-webpki-roots = ["dep:reqwest", "reqwest/rustls-tls-webpki-roots"]
+# Enable rustls for TLS support (uses rustls-platform-verifier for roots in reqwest 0.13)
+rustls = ["dep:reqwest", "reqwest/rustls"]
 # Enable native-tls for TLS support
 native-tls = ["dep:reqwest", "reqwest/native-tls"]
 # Remove dependency on OpenSSL
@@ -141,7 +139,6 @@ _api = [
     "dep:futures",
     "dep:rand",
     "dep:reqwest",
-    "dep:reqwest-eventsource",
     "dep:thiserror",
     "dep:tokio",
     "dep:tokio-stream",
@@ -166,10 +163,11 @@ bytes = { version = "1.11", optional = true }
 async-openai-macros = { path = "../async-openai-macros", version = "0.1.1", optional = true }
 base64 = { version = "0.22", optional = true }
 rand = { version = "0.9", optional = true }
-reqwest = { version = "0.12", features = [
+reqwest = { version = "0.13", features = [
   "json",
   "stream",
   "multipart",
+  "query",
 ], default-features = false, optional = true }
 thiserror = { version = "2", optional = true }
 tracing = { version = "0.1", optional = true }
@@ -188,7 +186,6 @@ futures = { version = "0.3", optional = true }
 tokio = { version = "1", features = ["fs", "macros"], optional = true }
 tokio-stream = { version = "0.1", optional = true }
 tokio-util = { version = "0.7", features = ["codec", "io-util"], optional = true }
-reqwest-eventsource = { version = "0.6.0", optional = true }
 eventsource-stream = { version = "0.2", optional = true }
 ## For Realtime websocket
 tokio-tungstenite = { version = "0.28", optional = true, default-features = false }

--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -5,8 +5,6 @@ use bytes::Bytes;
 #[cfg(not(target_family = "wasm"))]
 use futures::{stream::StreamExt, Stream};
 use reqwest::{header::HeaderMap, multipart::Form, Response};
-#[cfg(not(target_family = "wasm"))]
-use reqwest_eventsource::{Error as EventSourceError, Event, EventSource, RequestBuilderExt};
 use serde::{de::DeserializeOwned, Serialize};
 
 #[cfg(not(target_family = "wasm"))]
@@ -484,62 +482,11 @@ impl<C: Config> Client<C> {
         O: DeserializeOwned + std::marker::Send + 'static,
     {
         // Build and execute request manually since multipart::Form is not Clone
-        // and .eventsource() requires cloneability
         let request_builder = self
             .build_request_builder(reqwest::Method::POST, path, request_options)
             .multipart(<Form as AsyncTryFrom<F>>::try_from(form.clone()).await?);
 
-        let response = request_builder.send().await.map_err(OpenAIError::Reqwest)?;
-
-        // Check for error status
-        if !response.status().is_success() {
-            return Err(read_response(response).await.unwrap_err());
-        }
-
-        // Convert response body to EventSource stream
-        let stream = response
-            .bytes_stream()
-            .map(|result| result.map_err(std::io::Error::other));
-        let event_stream = eventsource_stream::EventStream::new(stream);
-
-        // Convert EventSource stream to our expected format
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-
-        tokio::spawn(async move {
-            use futures::StreamExt;
-            let mut event_stream = std::pin::pin!(event_stream);
-
-            while let Some(event_result) = event_stream.next().await {
-                match event_result {
-                    Err(e) => {
-                        if let Err(_e) = tx.send(Err(OpenAIError::StreamError(Box::new(
-                            StreamError::EventStream(e.to_string()),
-                        )))) {
-                            break;
-                        }
-                    }
-                    Ok(event) => {
-                        // eventsource_stream::Event is a struct with data field
-                        if event.data == "[DONE]" {
-                            break;
-                        }
-
-                        let response = match serde_json::from_str::<O>(&event.data) {
-                            Err(e) => Err(map_deserialization_error(e, event.data.as_bytes())),
-                            Ok(output) => Ok(output),
-                        };
-
-                        if let Err(_e) = tx.send(response) {
-                            break;
-                        }
-                    }
-                }
-            }
-        });
-
-        Ok(Box::pin(
-            tokio_stream::wrappers::UnboundedReceiverStream::new(rx),
-        ))
+        Ok(stream(request_builder).await)
     }
 
     /// Execute a HTTP request and retry on rate limit (non-WASM version with backoff)
@@ -649,9 +596,7 @@ impl<C: Config> Client<C> {
             .build_request_builder(reqwest::Method::POST, path, request_options)
             .json(&request);
 
-        let event_source = request_builder.eventsource().unwrap();
-
-        stream(event_source).await
+        stream(request_builder).await
     }
 
     #[allow(unused)]
@@ -671,9 +616,7 @@ impl<C: Config> Client<C> {
             .build_request_builder(reqwest::Method::POST, path, request_options)
             .json(&request);
 
-        let event_source = request_builder.eventsource().unwrap();
-
-        stream_mapped_raw_events(event_source, event_mapper).await
+        stream_mapped_raw_events(request_builder, event_mapper).await
     }
 
     /// Make HTTP GET request to receive SSE
@@ -690,9 +633,7 @@ impl<C: Config> Client<C> {
         let request_builder =
             self.build_request_builder(reqwest::Method::GET, path, request_options);
 
-        let event_source = request_builder.eventsource().unwrap();
-
-        stream(event_source).await
+        stream(request_builder).await
     }
 }
 
@@ -724,23 +665,11 @@ async fn read_response(response: Response) -> Result<(Bytes, HeaderMap), OpenAIE
     Ok((bytes, headers))
 }
 
-#[cfg(not(target_family = "wasm"))]
-async fn map_stream_error(value: EventSourceError) -> OpenAIError {
-    match value {
-        EventSourceError::InvalidStatusCode(status_code, response) => {
-            read_response(response).await.expect_err(&format!(
-                "Unreachable because read_response returns err when status_code {status_code} is invalid"
-            ))
-        }
-        _ => OpenAIError::StreamError(Box::new(StreamError::ReqwestEventSource(value))),
-    }
-}
-
 /// Request which responds with SSE.
 /// [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format)
 #[cfg(not(target_family = "wasm"))]
 pub(crate) async fn stream<O>(
-    mut event_source: EventSource,
+    request_builder: reqwest::RequestBuilder,
 ) -> Pin<Box<dyn Stream<Item = Result<O, OpenAIError>> + Send>>
 where
     O: DeserializeOwned + std::marker::Send + 'static,
@@ -748,49 +677,48 @@ where
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
     tokio::spawn(async move {
-        while let Some(ev) = event_source.next().await {
-            match ev {
+        let response = match request_builder.send().await {
+            Ok(r) => r,
+            Err(e) => {
+                let _ = tx.send(Err(OpenAIError::Reqwest(e)));
+                return;
+            }
+        };
+        if !response.status().is_success() {
+            if let Err(e) = read_response(response).await {
+                let _ = tx.send(Err(e));
+            }
+            return;
+        }
+        let byte_stream = response
+            .bytes_stream()
+            .map(|r| r.map_err(std::io::Error::other));
+        let mut event_stream = std::pin::pin!(eventsource_stream::EventStream::new(byte_stream));
+
+        while let Some(ev) = event_stream.next().await {
+            let event = match ev {
+                Ok(e) => e,
                 Err(e) => {
-                    // Handle StreamEnded gracefully - it's a normal end of stream, not an error
-                    // https://github.com/64bit/async-openai/issues/456
-                    match &e {
-                        EventSourceError::StreamEnded => {
-                            break;
-                        }
-                        _ => {
-                            if let Err(_e) = tx.send(Err(map_stream_error(e).await)) {
-                                // rx dropped
-                                break;
-                            }
-                        }
-                    }
+                    let _ = tx.send(Err(OpenAIError::StreamError(Box::new(
+                        StreamError::EventStream(e.to_string()),
+                    ))));
+                    break;
                 }
-                Ok(event) => match event {
-                    Event::Message(message) => {
-                        if message.data == "[DONE]" {
-                            break;
-                        }
+            };
+            if event.data == "[DONE]" {
+                break;
+            }
+            if event.event == "keepalive" {
+                continue;
+            }
 
-                        if message.event == "keepalive" {
-                            continue;
-                        }
+            let response = serde_json::from_str::<O>(&event.data)
+                .map_err(|e| map_deserialization_error(e, event.data.as_bytes()));
 
-                        let response = match serde_json::from_str::<O>(&message.data) {
-                            Err(e) => Err(map_deserialization_error(e, message.data.as_bytes())),
-                            Ok(output) => Ok(output),
-                        };
-
-                        if let Err(_e) = tx.send(response) {
-                            // rx dropped
-                            break;
-                        }
-                    }
-                    Event::Open => continue,
-                },
+            if tx.send(response).is_err() {
+                break;
             }
         }
-
-        event_source.close();
     });
 
     Box::pin(tokio_stream::wrappers::UnboundedReceiverStream::new(rx))
@@ -798,7 +726,7 @@ where
 
 #[cfg(not(target_family = "wasm"))]
 pub(crate) async fn stream_mapped_raw_events<O>(
-    mut event_source: EventSource,
+    request_builder: reqwest::RequestBuilder,
     event_mapper: impl Fn(eventsource_stream::Event) -> Result<O, OpenAIError> + Send + 'static,
 ) -> Pin<Box<dyn Stream<Item = Result<O, OpenAIError>> + Send>>
 where
@@ -807,52 +735,50 @@ where
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
     tokio::spawn(async move {
-        while let Some(ev) = event_source.next().await {
-            match ev {
+        let response = match request_builder.send().await {
+            Ok(r) => r,
+            Err(e) => {
+                let _ = tx.send(Err(OpenAIError::Reqwest(e)));
+                return;
+            }
+        };
+        if !response.status().is_success() {
+            if let Err(e) = read_response(response).await {
+                let _ = tx.send(Err(e));
+            }
+            return;
+        }
+        let byte_stream = response
+            .bytes_stream()
+            .map(|r| r.map_err(std::io::Error::other));
+        let mut event_stream = std::pin::pin!(eventsource_stream::EventStream::new(byte_stream));
+
+        while let Some(ev) = event_stream.next().await {
+            let event = match ev {
+                Ok(e) => e,
                 Err(e) => {
-                    // Handle StreamEnded gracefully - it's a normal end of stream, not an error
-                    // https://github.com/64bit/async-openai/issues/456
-                    match &e {
-                        EventSourceError::StreamEnded => {
-                            break;
-                        }
-                        _ => {
-                            if let Err(_e) = tx.send(Err(map_stream_error(e).await)) {
-                                // rx dropped
-                                break;
-                            }
-                        }
-                    }
+                    let _ = tx.send(Err(OpenAIError::StreamError(Box::new(
+                        StreamError::EventStream(e.to_string()),
+                    ))));
+                    break;
                 }
-                Ok(event) => match event {
-                    Event::Message(message) => {
-                        let mut done = false;
+            };
+            let done = event.data == "[DONE]";
 
-                        if message.data == "[DONE]" {
-                            done = true;
-                        }
+            if event.event == "keepalive" {
+                continue;
+            }
 
-                        if message.event == "keepalive" {
-                            continue;
-                        }
+            let response = event_mapper(event);
 
-                        let response = event_mapper(message);
+            if tx.send(response).is_err() {
+                break;
+            }
 
-                        if let Err(_e) = tx.send(response) {
-                            // rx dropped
-                            break;
-                        }
-
-                        if done {
-                            break;
-                        }
-                    }
-                    Event::Open => continue,
-                },
+            if done {
+                break;
             }
         }
-
-        event_source.close();
     });
 
     Box::pin(tokio_stream::wrappers::UnboundedReceiverStream::new(rx))

--- a/async-openai/src/error.rs
+++ b/async-openai/src/error.rs
@@ -71,9 +71,6 @@ impl std::error::Error for OpenAIError {}
 #[cfg(all(feature = "_api", not(target_family = "wasm")))]
 #[derive(Debug, thiserror::Error)]
 pub enum StreamError {
-    /// Underlying error from reqwest_eventsource library when reading the stream
-    #[error("{0}")]
-    ReqwestEventSource(#[from] reqwest_eventsource::Error),
     /// Error when a stream event does not match one of the expected values
     #[error("Unknown event: {0:#?}")]
     UnknownEvent(eventsource_stream::Event),


### PR DESCRIPTION
Bumps reqwest from 0.12 to 0.13. `reqwest-eventsource` is abandoned and has no 0.13 release, so rather than pull in the `aha-reqwest-eventsource` fork (suggested in #518), this drops the dependency entirely.

The multipart streaming path was already consuming SSE via `reqwest::Response::bytes_stream()` + the `eventsource-stream` crate; the other three streaming call sites (`post_stream`, `post_stream_mapped_raw_events`, `get_stream`) now use the same pattern. `eventsource-stream` was already a direct dependency, so this is one fewer crate in the tree.

Also drops the `rustls-webpki-roots` feature: reqwest 0.13 unified TLS roots behind the `rustls` feature (via `rustls-platform-verifier`), and the webpki variant is no longer a distinct upstream option. Users who need explicit webpki roots can configure them through reqwest's `ClientBuilder`.

Net: -80 LOC, no new deps.
