### PR TITLE
`From<OutputItem> for Item` (and `InputItem`) for multi-turn responses

### DIFF
--- a/async-openai/src/types/responses/impls.rs
+++ b/async-openai/src/types/responses/impls.rs
@@ -1,20 +1,34 @@
 use crate::types::mcp::MCPTool;
 use crate::types::responses::{
-    ApplyPatchToolCallItemParam, ApplyPatchToolCallOutputItemParam, CodeInterpreterContainerAuto,
-    CodeInterpreterTool, CodeInterpreterToolCall, CodeInterpreterToolContainer,
-    ComputerCallOutputItemParam, ComputerTool, ComputerToolCall, ComputerUsePreviewTool,
-    ConversationParam, CustomToolCall, CustomToolCallOutput, CustomToolParam, EasyInputContent,
-    EasyInputMessage, FileSearchTool, FileSearchToolCall, FunctionCallOutput,
-    FunctionCallOutputItemParam, FunctionShellCallItemParam, FunctionShellCallOutputItemParam,
-    FunctionTool, FunctionToolCall, ImageGenTool, ImageGenToolCall, InputContent, InputFileContent,
+    ApplyPatchCallOutputStatus, ApplyPatchCallOutputStatusParam, ApplyPatchCallStatus,
+    ApplyPatchCallStatusParam, ApplyPatchCreateFileOperation, ApplyPatchCreateFileOperationParam,
+    ApplyPatchDeleteFileOperation, ApplyPatchDeleteFileOperationParam, ApplyPatchOperation,
+    ApplyPatchOperationParam, ApplyPatchToolCall, ApplyPatchToolCallItemParam,
+    ApplyPatchToolCallOutput, ApplyPatchToolCallOutputItemParam, ApplyPatchUpdateFileOperation,
+    ApplyPatchUpdateFileOperationParam, CodeInterpreterContainerAuto, CodeInterpreterTool,
+    CodeInterpreterToolCall, CodeInterpreterToolContainer, CompactionBody,
+    CompactionSummaryItemParam, ComputerCallOutputItemParam, ComputerTool, ComputerToolCall,
+    ComputerToolCallOutputResource, ComputerUsePreviewTool, ContainerReferenceParam,
+    ContainerReferenceResource, ConversationParam, CustomToolCall, CustomToolCallOutput,
+    CustomToolCallOutputResource, CustomToolParam, EasyInputContent, EasyInputMessage,
+    FileSearchTool, FileSearchToolCall, FunctionCallOutput, FunctionCallOutputItemParam,
+    FunctionCallOutputStatusEnum, FunctionCallStatus, FunctionShellAction, FunctionShellActionParam,
+    FunctionShellCall, FunctionShellCallEnvironment, FunctionShellCallItemEnvironment,
+    FunctionShellCallItemParam, FunctionShellCallItemStatus, FunctionShellCallOutput,
+    FunctionShellCallOutputContent, FunctionShellCallOutputContentParam,
+    FunctionShellCallOutputExitOutcome, FunctionShellCallOutputExitOutcomeParam,
+    FunctionShellCallOutputItemParam, FunctionShellCallOutputOutcome,
+    FunctionShellCallOutputOutcomeParam, FunctionTool, FunctionToolCall,
+    FunctionToolCallOutputResource, ImageGenTool, ImageGenToolCall, InputContent, InputFileContent,
     InputImageContent, InputItem, InputMessage, InputParam, InputTextContent, Item, ItemReference,
-    ItemReferenceType, LocalShellToolCall, LocalShellToolCallOutput, MCPApprovalRequest,
-    MCPApprovalResponse, MCPListTools, MCPToolCall, MessageItem, MessageType, NamespaceToolParam,
-    OutputMessage, OutputMessageContent, OutputTextContent, Prompt, Reasoning, ReasoningEffort,
-    ReasoningItem, ReasoningSummary, RefusalContent, ResponseFormatJsonSchema,
-    ResponsePromptVariables, ResponseStreamOptions, ResponseTextParam, Role,
-    TextResponseFormatConfiguration, Tool, ToolChoiceCustom, ToolChoiceFunction, ToolChoiceMCP,
-    ToolChoiceOptions, ToolChoiceParam, ToolChoiceTypes, ToolSearchCallItemParam,
+    ItemReferenceType, LocalEnvironmentParam, LocalShellCallStatus, LocalShellToolCall,
+    LocalShellToolCallOutput, MCPApprovalRequest, MCPApprovalResponse, MCPListTools, MCPToolCall,
+    MessageItem, MessageType, NamespaceToolParam, OutputItem, OutputMessage, OutputMessageContent,
+    OutputStatus, OutputTextContent, Prompt, Reasoning, ReasoningEffort, ReasoningItem,
+    ReasoningSummary, RefusalContent, ResponseFormatJsonSchema, ResponsePromptVariables,
+    ResponseStreamOptions, ResponseTextParam, Role, TextResponseFormatConfiguration, Tool,
+    ToolChoiceCustom, ToolChoiceFunction, ToolChoiceMCP, ToolChoiceOptions, ToolChoiceParam,
+    ToolChoiceTypes, ToolSearchCall, ToolSearchCallItemParam, ToolSearchOutput,
     ToolSearchOutputItemParam, ToolSearchToolParam, WebSearchTool, WebSearchToolCall,
 };
 
@@ -708,5 +722,355 @@ impl ItemReference {
             r#type: Some(ItemReferenceType::ItemReference),
             id: id.into(),
         }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// OutputItem -> Item / InputItem (multi-turn responses helpers)
+//
+// The Responses API requires reasoning items to be echoed back into the
+// next request's `input` alongside the function-call items they preceded —
+// otherwise the server rejects the request with
+// `Item 'fc_...' was provided without its required 'reasoning' item: ...`.
+// In the official Python and Node SDKs the canonical pattern is just
+// `input_list += response.output`, since their input/output item types
+// are the same. In Rust the OpenAPI-derived schemas split into Item (input
+// side) and OutputItem (output side), so an explicit conversion is needed.
+//
+// The conversions below give that "just append the output" ergonomic via
+// `From<OutputItem> for Item` (and through it, `From<OutputItem> for
+// InputItem`). For variants where input and output already share a struct
+// the conversion is a one-liner; for the handful of variants where the
+// schemas differ (resource types carry required `id`/`status`, while their
+// input-side `*ItemParam` counterparts have those optional), per-pair
+// `From` impls map the fields so callers don't have to write boilerplate
+// per use site.
+//
+// References:
+//   - https://github.com/64bit/async-openai/issues/492
+//   - https://platform.openai.com/docs/guides/conversation-state
+// ──────────────────────────────────────────────────────────────────────────
+
+// Status enum mappings (resource side → param side).
+
+impl From<FunctionCallOutputStatusEnum> for OutputStatus {
+    fn from(status: FunctionCallOutputStatusEnum) -> Self {
+        match status {
+            FunctionCallOutputStatusEnum::InProgress => OutputStatus::InProgress,
+            FunctionCallOutputStatusEnum::Completed => OutputStatus::Completed,
+            FunctionCallOutputStatusEnum::Incomplete => OutputStatus::Incomplete,
+        }
+    }
+}
+
+impl From<FunctionCallStatus> for OutputStatus {
+    fn from(status: FunctionCallStatus) -> Self {
+        match status {
+            FunctionCallStatus::InProgress => OutputStatus::InProgress,
+            FunctionCallStatus::Completed => OutputStatus::Completed,
+            FunctionCallStatus::Incomplete => OutputStatus::Incomplete,
+        }
+    }
+}
+
+impl From<LocalShellCallStatus> for FunctionShellCallItemStatus {
+    fn from(status: LocalShellCallStatus) -> Self {
+        match status {
+            LocalShellCallStatus::InProgress => FunctionShellCallItemStatus::InProgress,
+            LocalShellCallStatus::Completed => FunctionShellCallItemStatus::Completed,
+            LocalShellCallStatus::Incomplete => FunctionShellCallItemStatus::Incomplete,
+        }
+    }
+}
+
+impl From<ApplyPatchCallStatus> for ApplyPatchCallStatusParam {
+    fn from(status: ApplyPatchCallStatus) -> Self {
+        match status {
+            ApplyPatchCallStatus::InProgress => ApplyPatchCallStatusParam::InProgress,
+            ApplyPatchCallStatus::Completed => ApplyPatchCallStatusParam::Completed,
+        }
+    }
+}
+
+impl From<ApplyPatchCallOutputStatus> for ApplyPatchCallOutputStatusParam {
+    fn from(status: ApplyPatchCallOutputStatus) -> Self {
+        match status {
+            ApplyPatchCallOutputStatus::Completed => ApplyPatchCallOutputStatusParam::Completed,
+            ApplyPatchCallOutputStatus::Failed => ApplyPatchCallOutputStatusParam::Failed,
+        }
+    }
+}
+
+// Shell environment / outcome mappings.
+
+impl From<ContainerReferenceResource> for ContainerReferenceParam {
+    fn from(r: ContainerReferenceResource) -> Self {
+        ContainerReferenceParam {
+            container_id: r.container_id,
+        }
+    }
+}
+
+impl From<FunctionShellCallEnvironment> for FunctionShellCallItemEnvironment {
+    fn from(env: FunctionShellCallEnvironment) -> Self {
+        match env {
+            // The response side carries no payload for `Local`; the param
+            // side accepts an optional `skills` list which we leave None
+            // (it's a request-only knob).
+            FunctionShellCallEnvironment::Local => FunctionShellCallItemEnvironment::Local(
+                LocalEnvironmentParam { skills: None },
+            ),
+            FunctionShellCallEnvironment::ContainerReference(r) => {
+                FunctionShellCallItemEnvironment::ContainerReference(r.into())
+            }
+        }
+    }
+}
+
+impl From<FunctionShellCallOutputExitOutcome> for FunctionShellCallOutputExitOutcomeParam {
+    fn from(o: FunctionShellCallOutputExitOutcome) -> Self {
+        FunctionShellCallOutputExitOutcomeParam {
+            exit_code: o.exit_code,
+        }
+    }
+}
+
+impl From<FunctionShellCallOutputOutcome> for FunctionShellCallOutputOutcomeParam {
+    fn from(o: FunctionShellCallOutputOutcome) -> Self {
+        match o {
+            FunctionShellCallOutputOutcome::Timeout => FunctionShellCallOutputOutcomeParam::Timeout,
+            FunctionShellCallOutputOutcome::Exit(e) => {
+                FunctionShellCallOutputOutcomeParam::Exit(e.into())
+            }
+        }
+    }
+}
+
+impl From<FunctionShellCallOutputContent> for FunctionShellCallOutputContentParam {
+    fn from(c: FunctionShellCallOutputContent) -> Self {
+        FunctionShellCallOutputContentParam {
+            stdout: c.stdout,
+            stderr: c.stderr,
+            outcome: c.outcome.into(),
+        }
+    }
+}
+
+impl From<FunctionShellAction> for FunctionShellActionParam {
+    fn from(a: FunctionShellAction) -> Self {
+        FunctionShellActionParam {
+            commands: a.commands,
+            timeout_ms: a.timeout_ms,
+            max_output_length: a.max_output_length,
+        }
+    }
+}
+
+// ApplyPatch operation mappings.
+
+impl From<ApplyPatchCreateFileOperation> for ApplyPatchCreateFileOperationParam {
+    fn from(op: ApplyPatchCreateFileOperation) -> Self {
+        ApplyPatchCreateFileOperationParam {
+            path: op.path,
+            diff: op.diff,
+        }
+    }
+}
+
+impl From<ApplyPatchDeleteFileOperation> for ApplyPatchDeleteFileOperationParam {
+    fn from(op: ApplyPatchDeleteFileOperation) -> Self {
+        ApplyPatchDeleteFileOperationParam { path: op.path }
+    }
+}
+
+impl From<ApplyPatchUpdateFileOperation> for ApplyPatchUpdateFileOperationParam {
+    fn from(op: ApplyPatchUpdateFileOperation) -> Self {
+        ApplyPatchUpdateFileOperationParam {
+            path: op.path,
+            diff: op.diff,
+        }
+    }
+}
+
+impl From<ApplyPatchOperation> for ApplyPatchOperationParam {
+    fn from(op: ApplyPatchOperation) -> Self {
+        match op {
+            ApplyPatchOperation::CreateFile(o) => ApplyPatchOperationParam::CreateFile(o.into()),
+            ApplyPatchOperation::DeleteFile(o) => ApplyPatchOperationParam::DeleteFile(o.into()),
+            ApplyPatchOperation::UpdateFile(o) => ApplyPatchOperationParam::UpdateFile(o.into()),
+        }
+    }
+}
+
+// Per-resource-output → input-param conversions. Required `id` / `status`
+// fields on the resource side become wrapped in `Some(...)` on the input
+// side; status enums fold through the `From` impls above. The `created_by`
+// field exists only on the resource side and is dropped on the way in —
+// it's a server-assigned annotation that the input schema doesn't accept.
+
+impl From<FunctionToolCallOutputResource> for FunctionCallOutputItemParam {
+    fn from(r: FunctionToolCallOutputResource) -> Self {
+        FunctionCallOutputItemParam {
+            call_id: r.call_id,
+            output: r.output,
+            id: Some(r.id),
+            status: Some(r.status.into()),
+        }
+    }
+}
+
+impl From<ComputerToolCallOutputResource> for ComputerCallOutputItemParam {
+    fn from(r: ComputerToolCallOutputResource) -> Self {
+        ComputerCallOutputItemParam {
+            call_id: r.call_id,
+            output: r.output,
+            acknowledged_safety_checks: r.acknowledged_safety_checks,
+            id: Some(r.id),
+            // ComputerCallOutputStatus has a `Failed` variant that
+            // OutputStatus doesn't model. The Responses API silently
+            // accepts a missing status here, so collapse `Failed` to None
+            // rather than fabricate a value the schema can't represent.
+            status: match r.status {
+                crate::types::responses::ComputerCallOutputStatus::InProgress => {
+                    Some(OutputStatus::InProgress)
+                }
+                crate::types::responses::ComputerCallOutputStatus::Completed => {
+                    Some(OutputStatus::Completed)
+                }
+                crate::types::responses::ComputerCallOutputStatus::Incomplete => {
+                    Some(OutputStatus::Incomplete)
+                }
+                crate::types::responses::ComputerCallOutputStatus::Failed => None,
+            },
+        }
+    }
+}
+
+impl From<CustomToolCallOutputResource> for CustomToolCallOutput {
+    fn from(r: CustomToolCallOutputResource) -> Self {
+        CustomToolCallOutput {
+            call_id: r.call_id,
+            output: r.output,
+            id: Some(r.id),
+        }
+    }
+}
+
+impl From<FunctionShellCall> for FunctionShellCallItemParam {
+    fn from(c: FunctionShellCall) -> Self {
+        FunctionShellCallItemParam {
+            id: Some(c.id),
+            call_id: c.call_id,
+            action: c.action.into(),
+            status: Some(c.status.into()),
+            environment: c.environment.map(Into::into),
+        }
+    }
+}
+
+impl From<FunctionShellCallOutput> for FunctionShellCallOutputItemParam {
+    fn from(o: FunctionShellCallOutput) -> Self {
+        FunctionShellCallOutputItemParam {
+            id: Some(o.id),
+            call_id: o.call_id,
+            output: o.output.into_iter().map(Into::into).collect(),
+            max_output_length: o.max_output_length,
+        }
+    }
+}
+
+impl From<ApplyPatchToolCall> for ApplyPatchToolCallItemParam {
+    fn from(c: ApplyPatchToolCall) -> Self {
+        ApplyPatchToolCallItemParam {
+            id: Some(c.id),
+            call_id: c.call_id,
+            status: c.status.into(),
+            operation: c.operation.into(),
+        }
+    }
+}
+
+impl From<ApplyPatchToolCallOutput> for ApplyPatchToolCallOutputItemParam {
+    fn from(o: ApplyPatchToolCallOutput) -> Self {
+        ApplyPatchToolCallOutputItemParam {
+            id: Some(o.id),
+            call_id: o.call_id,
+            status: o.status.into(),
+            output: o.output,
+        }
+    }
+}
+
+impl From<CompactionBody> for CompactionSummaryItemParam {
+    fn from(b: CompactionBody) -> Self {
+        CompactionSummaryItemParam {
+            id: Some(b.id),
+            encrypted_content: b.encrypted_content,
+        }
+    }
+}
+
+impl From<ToolSearchCall> for ToolSearchCallItemParam {
+    fn from(c: ToolSearchCall) -> Self {
+        ToolSearchCallItemParam {
+            id: Some(c.id),
+            call_id: c.call_id,
+            execution: Some(c.execution),
+            arguments: c.arguments,
+            status: Some(c.status.into()),
+        }
+    }
+}
+
+impl From<ToolSearchOutput> for ToolSearchOutputItemParam {
+    fn from(o: ToolSearchOutput) -> Self {
+        ToolSearchOutputItemParam {
+            id: Some(o.id),
+            call_id: o.call_id,
+            execution: Some(o.execution),
+            tools: o.tools,
+            status: Some(o.status.into()),
+        }
+    }
+}
+
+// Top-level: any output item rolls into an Item, and through the existing
+// `From<Item> for InputItem` impl, into an InputItem too. This is the entry
+// point callers actually want — see the `responses-multi-turn-reasoning`
+// example for the round-trip pattern.
+
+impl From<OutputItem> for Item {
+    fn from(item: OutputItem) -> Self {
+        match item {
+            OutputItem::Message(m) => Item::Message(m.into()),
+            OutputItem::FileSearchCall(c) => c.into(),
+            OutputItem::FunctionCall(c) => c.into(),
+            OutputItem::FunctionCallOutput(o) => Item::FunctionCallOutput(o.into()),
+            OutputItem::WebSearchCall(c) => c.into(),
+            OutputItem::ComputerCall(c) => c.into(),
+            OutputItem::ComputerCallOutput(o) => Item::ComputerCallOutput(o.into()),
+            OutputItem::Reasoning(r) => r.into(),
+            OutputItem::Compaction(c) => Item::Compaction(c.into()),
+            OutputItem::ImageGenerationCall(c) => c.into(),
+            OutputItem::CodeInterpreterCall(c) => c.into(),
+            OutputItem::LocalShellCall(c) => c.into(),
+            OutputItem::ShellCall(c) => Item::ShellCall(c.into()),
+            OutputItem::ShellCallOutput(o) => Item::ShellCallOutput(o.into()),
+            OutputItem::ApplyPatchCall(c) => Item::ApplyPatchCall(c.into()),
+            OutputItem::ApplyPatchCallOutput(o) => Item::ApplyPatchCallOutput(o.into()),
+            OutputItem::McpCall(c) => c.into(),
+            OutputItem::McpListTools(c) => c.into(),
+            OutputItem::McpApprovalRequest(c) => c.into(),
+            OutputItem::CustomToolCall(c) => c.into(),
+            OutputItem::CustomToolCallOutput(o) => Item::CustomToolCallOutput(o.into()),
+            OutputItem::ToolSearchCall(c) => Item::ToolSearchCall(c.into()),
+            OutputItem::ToolSearchOutput(o) => Item::ToolSearchOutput(o.into()),
+        }
+    }
+}
+
+impl From<OutputItem> for InputItem {
+    fn from(item: OutputItem) -> Self {
+        Item::from(item).into()
     }
 }

--- a/async-openai/src/types/responses/impls.rs
+++ b/async-openai/src/types/responses/impls.rs
@@ -12,10 +12,10 @@ use crate::types::responses::{
     ContainerReferenceResource, ConversationParam, CustomToolCall, CustomToolCallOutput,
     CustomToolCallOutputResource, CustomToolParam, EasyInputContent, EasyInputMessage,
     FileSearchTool, FileSearchToolCall, FunctionCallOutput, FunctionCallOutputItemParam,
-    FunctionCallOutputStatusEnum, FunctionCallStatus, FunctionShellAction, FunctionShellActionParam,
-    FunctionShellCall, FunctionShellCallEnvironment, FunctionShellCallItemEnvironment,
-    FunctionShellCallItemParam, FunctionShellCallItemStatus, FunctionShellCallOutput,
-    FunctionShellCallOutputContent, FunctionShellCallOutputContentParam,
+    FunctionCallOutputStatusEnum, FunctionCallStatus, FunctionShellAction,
+    FunctionShellActionParam, FunctionShellCall, FunctionShellCallEnvironment,
+    FunctionShellCallItemEnvironment, FunctionShellCallItemParam, FunctionShellCallItemStatus,
+    FunctionShellCallOutput, FunctionShellCallOutputContent, FunctionShellCallOutputContentParam,
     FunctionShellCallOutputExitOutcome, FunctionShellCallOutputExitOutcomeParam,
     FunctionShellCallOutputItemParam, FunctionShellCallOutputOutcome,
     FunctionShellCallOutputOutcomeParam, FunctionTool, FunctionToolCall,
@@ -817,9 +817,9 @@ impl From<FunctionShellCallEnvironment> for FunctionShellCallItemEnvironment {
             // The response side carries no payload for `Local`; the param
             // side accepts an optional `skills` list which we leave None
             // (it's a request-only knob).
-            FunctionShellCallEnvironment::Local => FunctionShellCallItemEnvironment::Local(
-                LocalEnvironmentParam { skills: None },
-            ),
+            FunctionShellCallEnvironment::Local => {
+                FunctionShellCallItemEnvironment::Local(LocalEnvironmentParam { skills: None })
+            }
             FunctionShellCallEnvironment::ContainerReference(r) => {
                 FunctionShellCallItemEnvironment::ContainerReference(r.into())
             }

--- a/async-openai/tests/responses_output_to_input.rs
+++ b/async-openai/tests/responses_output_to_input.rs
@@ -1,0 +1,148 @@
+//! Round-trip tests for `From<OutputItem> for Item` / `InputItem`.
+//!
+//! Reasoning models emit `Reasoning` items in `response.output` that the
+//! Responses API requires you to echo back into the next request's `input`
+//! alongside the function calls they preceded. These tests cover the
+//! conversion paths the bug-prone variants rely on; the headline scenarios
+//! are reasoning + function_call, which is what the API errors on if the
+//! pairing is dropped (see issue #492).
+
+#![cfg(feature = "response-types")]
+
+use async_openai::types::responses::{
+    ApplyPatchCallOutputStatus, ApplyPatchCallStatus, ApplyPatchOperation, ApplyPatchToolCall,
+    ApplyPatchToolCallOutput, ApplyPatchUpdateFileOperation, CompactionBody, FunctionCallOutput,
+    FunctionCallOutputStatusEnum, FunctionToolCall, FunctionToolCallOutputResource, InputItem,
+    Item, OutputItem, ReasoningItem,
+};
+use serde_json::json;
+
+#[test]
+fn reasoning_round_trips_to_item() {
+    // Synthesize a ReasoningItem the way the API would deliver one: an id
+    // and an empty summary list (`encrypted_content` is the typical
+    // payload, populated when `include: ["reasoning.encrypted_content"]`
+    // is set on the request).
+    let reasoning: ReasoningItem = serde_json::from_value(json!({
+        "id": "rs_abc123",
+        "type": "reasoning",
+        "summary": [],
+        "encrypted_content": "opaque-bytes",
+    }))
+    .expect("deserialize reasoning item");
+
+    let output = OutputItem::Reasoning(reasoning.clone());
+    let as_item: Item = output.into();
+    match as_item {
+        Item::Reasoning(r) => {
+            assert_eq!(r.id, reasoning.id);
+            assert_eq!(r.encrypted_content.as_deref(), Some("opaque-bytes"));
+        }
+        other => panic!("expected Item::Reasoning, got {other:?}"),
+    }
+}
+
+#[test]
+fn reasoning_then_function_call_round_trip_for_input() {
+    // The headline scenario: a reasoning model emits Reasoning + FunctionCall
+    // in its output; the next request must echo BOTH back so the API's
+    // "function_call without its required reasoning item" check passes.
+    let reasoning: ReasoningItem = serde_json::from_value(json!({
+        "id": "rs_pair",
+        "type": "reasoning",
+        "summary": [],
+    }))
+    .unwrap();
+    let function_call = FunctionToolCall {
+        arguments: r#"{"location":"Paris","units":"celsius"}"#.into(),
+        call_id: "call_pair".into(),
+        name: "get_weather".into(),
+        namespace: None,
+        id: Some("fc_pair".into()),
+        status: None,
+    };
+
+    let output = vec![
+        OutputItem::Reasoning(reasoning),
+        OutputItem::FunctionCall(function_call.clone()),
+    ];
+
+    let echoed: Vec<InputItem> = output.into_iter().map(InputItem::from).collect();
+    assert_eq!(echoed.len(), 2);
+    assert!(matches!(echoed[0], InputItem::Item(Item::Reasoning(_))));
+    assert!(matches!(echoed[1], InputItem::Item(Item::FunctionCall(_))));
+}
+
+#[test]
+fn function_call_output_resource_drops_required_id_into_optional() {
+    // Resource side has `id: String` + `status: FunctionCallOutputStatusEnum`;
+    // the input-side `*ItemParam` has both as Option. Conversion should
+    // wrap them in Some so an echoed-back item carries the same identity.
+    let resource = FunctionToolCallOutputResource {
+        call_id: "call_42".into(),
+        output: FunctionCallOutput::Text("ok".into()),
+        id: "fco_42".into(),
+        status: FunctionCallOutputStatusEnum::Completed,
+        created_by: Some("svc".into()),
+    };
+
+    let item: Item = OutputItem::FunctionCallOutput(resource).into();
+    match item {
+        Item::FunctionCallOutput(p) => {
+            assert_eq!(p.call_id, "call_42");
+            assert_eq!(p.id.as_deref(), Some("fco_42"));
+            assert!(p.status.is_some());
+        }
+        other => panic!("expected FunctionCallOutput, got {other:?}"),
+    }
+}
+
+#[test]
+fn apply_patch_call_status_folds_through() {
+    let call = ApplyPatchToolCall {
+        id: "apc_1".into(),
+        call_id: "call_apc".into(),
+        status: ApplyPatchCallStatus::Completed,
+        operation: ApplyPatchOperation::UpdateFile(ApplyPatchUpdateFileOperation {
+            path: "src/main.rs".into(),
+            diff: "@@ -1 +1 @@\n-old\n+new\n".into(),
+        }),
+        created_by: None,
+    };
+    let item: Item = OutputItem::ApplyPatchCall(call).into();
+    let Item::ApplyPatchCall(p) = item else {
+        panic!("expected ApplyPatchCall");
+    };
+    assert_eq!(p.id.as_deref(), Some("apc_1"));
+}
+
+#[test]
+fn apply_patch_call_output_status_failed_folds_through() {
+    let out = ApplyPatchToolCallOutput {
+        id: "apco_1".into(),
+        call_id: "call_apco".into(),
+        status: ApplyPatchCallOutputStatus::Failed,
+        output: Some("patch did not apply cleanly".into()),
+        created_by: None,
+    };
+    let item: Item = OutputItem::ApplyPatchCallOutput(out).into();
+    let Item::ApplyPatchCallOutput(p) = item else {
+        panic!("expected ApplyPatchCallOutput");
+    };
+    assert_eq!(p.output.as_deref(), Some("patch did not apply cleanly"));
+}
+
+#[test]
+fn compaction_body_to_param() {
+    let body = CompactionBody {
+        id: "cmp_1".into(),
+        encrypted_content: "encrypted-blob".into(),
+        created_by: None,
+    };
+    let item: Item = OutputItem::Compaction(body).into();
+    let Item::Compaction(p) = item else {
+        panic!("expected Compaction");
+    };
+    assert_eq!(p.id.as_deref(), Some("cmp_1"));
+    assert_eq!(p.encrypted_content, "encrypted-blob");
+}

--- a/examples/responses-multi-turn-reasoning/Cargo.toml
+++ b/examples/responses-multi-turn-reasoning/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "responses-multi-turn-reasoning"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+async-openai = { path = "../../async-openai", features = ["responses"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }

--- a/examples/responses-multi-turn-reasoning/src/main.rs
+++ b/examples/responses-multi-turn-reasoning/src/main.rs
@@ -1,0 +1,134 @@
+//! Multi-turn Responses API with a reasoning model.
+//!
+//! Reasoning models (gpt-5 and friends) emit `Reasoning` items in
+//! `response.output` alongside any `FunctionCall` items they produce. The
+//! Responses API requires those reasoning items to be echoed back into the
+//! next request's `input` together with the function calls they preceded —
+//! otherwise the server rejects the request with:
+//!
+//! ```text
+//! Item 'fc_...' of type 'function_call' was provided without its required 'reasoning' item: 'rs_...'
+//! ```
+//!
+//! In the official Python and Node SDKs the canonical pattern is just
+//! `input_list += response.output`. In Rust the input/output schemas are
+//! split (`Item` vs `OutputItem`), so this example uses the
+//! `From<OutputItem> for InputItem` conversion to do the same thing.
+//!
+//! Run with: `OPENAI_API_KEY=... cargo run -p responses-multi-turn-reasoning`
+
+use async_openai::types::responses::{
+    CreateResponseArgs, EasyInputMessage, FunctionCallOutput, FunctionCallOutputItemParam,
+    FunctionTool, FunctionToolCall, InputItem, InputParam, Item, OutputItem, Tool,
+};
+use async_openai::Client;
+use serde::Deserialize;
+use std::error::Error;
+
+#[derive(Debug, Deserialize)]
+struct WeatherFunctionArgs {
+    location: String,
+    units: String,
+}
+
+fn check_weather(location: String, units: String) -> String {
+    format!("The weather in {location} is 25 {units}")
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let client = Client::new();
+
+    let tools = vec![Tool::Function(FunctionTool {
+        defer_loading: None,
+        name: "get_weather".to_string(),
+        description: Some("Retrieves current weather for the given location".to_string()),
+        parameters: Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "City and country e.g. Bogotá, Colombia"
+                },
+                "units": {
+                    "type": "string",
+                    "enum": ["celsius", "fahrenheit"],
+                    "description": "Units the temperature will be returned in."
+                }
+            },
+            "required": ["location", "units"],
+            "additionalProperties": false
+        })),
+        strict: Some(true),
+    })];
+
+    let mut input_items: Vec<InputItem> =
+        vec![EasyInputMessage::from("What's the weather like in Paris today?").into()];
+
+    // Turn 1: ask the model. With a reasoning model, response.output will
+    // typically contain one or more Reasoning items followed by a
+    // FunctionCall item.
+    let request = CreateResponseArgs::default()
+        .model("gpt-5")
+        .input(InputParam::Items(input_items.clone()))
+        .tools(tools.clone())
+        .build()?;
+    let response = client.responses().create(request).await?;
+
+    // Pull out the function call we need to execute, but DO NOT consume
+    // `response.output` yet — we need to round-trip the whole thing
+    // (reasoning items included) into the next request.
+    let function_call: FunctionToolCall = response
+        .output
+        .iter()
+        .find_map(|item| match item {
+            OutputItem::FunctionCall(fc) => Some(fc.clone()),
+            _ => None,
+        })
+        .ok_or("model did not request a function call")?;
+
+    let function_result = match function_call.name.as_str() {
+        "get_weather" => {
+            let args: WeatherFunctionArgs = serde_json::from_str(&function_call.arguments)?;
+            check_weather(args.location, args.units)
+        }
+        other => return Err(format!("unknown function {other}").into()),
+    };
+
+    // The fix: append the entire `response.output` into our running input,
+    // converted from OutputItem to InputItem. This carries the Reasoning
+    // items along with the FunctionCall, satisfying the API's pairing
+    // requirement on the next turn.
+    //
+    // Without this — for instance, pushing only the FunctionCall back —
+    // the next request fails with:
+    //   "Item 'fc_...' was provided without its required 'reasoning' item"
+    input_items.extend(response.output.into_iter().map(InputItem::from));
+
+    // And then the function call's result.
+    input_items.push(InputItem::Item(Item::FunctionCallOutput(
+        FunctionCallOutputItemParam {
+            call_id: function_call.call_id.clone(),
+            output: FunctionCallOutput::Text(function_result),
+            id: None,
+            status: None,
+        },
+    )));
+
+    // Turn 2: the model now sees its own reasoning trail and the tool
+    // result, and can compose a final answer.
+    let request = CreateResponseArgs::default()
+        .model("gpt-5")
+        .input(InputParam::Items(input_items))
+        .tools(tools)
+        .build()?;
+    let response = client.responses().create(request).await?;
+
+    if let Some(text) = response.output_text() {
+        println!("{text}");
+    } else {
+        println!("(no text in final response)");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #492

My code worked with 5.4 and started breaking with 5.5 and ~~I~~ Opus 4.7 did some investigation, I pulled the official python and node SDKs and had a look.

## Problem

When a reasoning model (gpt-5 etc.) is used through the Responses API with tool calls, the model's `response.output` contains `Reasoning` items alongside the `FunctionCall` items they preceded. The API requires those reasoning items to be echoed back into the next request's `input` together with the function calls. Otherwise the server rejects the second turn:

```
Item 'fc_...' of type 'function_call' was provided without its required 'reasoning' item: 'rs_...'
```

This is a recent server-side enforcement change (the same code worked previously, and the existing `responses-function-call` example silently has the same bug for a reasoning model — it only echoes back the `FunctionCall`).

In the official Python and Node SDKs the canonical pattern is one line:

```python
input_list += response.output  # python
```

```ts
inputItems.push(...response.output);  // node
```

both work because their input/output item types are the same. In Rust the OpenAPI-derived schemas split into `Item` (input side) and `OutputItem` (output side), and several variants have `*Resource` (output, required `id`/`status`) vs `*ItemParam` (input, optional `id`/`status`) flavors. So callers need a per-variant conversion to do what's a one-liner in the official SDKs — and most users don't realize they need to do it until the API rejects their request.