### PR TITLE
fix: check [DONE] SSE marker before deserialization in stream_mapped_raw_events

### DIFF
--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -791,12 +791,8 @@ where
     let event_stream = Box::pin(eventsource_stream::EventStream::new(byte_stream));
 
     Box::pin(futures::stream::unfold(
-        (event_stream, event_mapper, false),
-        |(mut event_stream, event_mapper, finished)| async move {
-            if finished {
-                return None;
-            }
-
+        (event_stream, event_mapper),
+        |(mut event_stream, event_mapper)| async move {
             loop {
                 let event = match event_stream.next().await {
                     Some(Ok(event)) => event,
@@ -805,20 +801,22 @@ where
                             Err(OpenAIError::StreamError(Box::new(
                                 StreamError::EventStream(error.to_string()),
                             ))),
-                            (event_stream, event_mapper, true),
+                            (event_stream, event_mapper),
                         ));
                     }
                     None => return None,
                 };
 
-                let done = event.data == "[DONE]";
+                if event.data == "[DONE]" {
+                    return None;
+                }
 
                 if event.event == "keepalive" {
                     continue;
                 }
 
                 let response = event_mapper(event);
-                return Some((response, (event_stream, event_mapper, done)));
+                return Some((response, (event_stream, event_mapper)));
             }
         },
     ))
@@ -856,7 +854,9 @@ where
                     break;
                 }
             };
-            let done = event.data == "[DONE]";
+            if event.data == "[DONE]" {
+                break;
+            }
 
             if event.event == "keepalive" {
                 continue;
@@ -865,10 +865,6 @@ where
             let response = event_mapper(event);
 
             if tx.send(response).is_err() {
-                break;
-            }
-
-            if done {
                 break;
             }
         }


### PR DESCRIPTION
## Summary

Fixes #542 — `[DONE]` SSE end-of-stream marker being passed to `serde_json::from_str` in `stream()`, causing a deserialization error.

## Root Cause

In v0.36.0 (PR #537), the streaming pipeline was refactored to remove `reqwest-eventsource`. The old `stream()` function checked for `[DONE]` **before** deserialization. The new `stream()` delegates to `stream_mapped_raw_events`, which checks `[DONE]` **after** the mapper closure — and the mapper in `stream()` is `serde_json::from_str`.

## Fix

Move the `[DONE]` check before the `event_mapper` call in both implementations:

- **WASM** (`futures::stream::unfold`): Check `[DONE]` and return `None` to end the stream cleanly. Removed the `finished` state variable since it's no longer needed.
- **Non-WASM** (`tokio::mpsc`): Check `[DONE]` and `break` before calling `event_mapper`.

## Test Plan

- Existing unit tests pass (15 passed, 11 skipped — require API key)
- Change is minimal and restores the pre-refactor behavior

## Before

```rust
let done = event.data == "[DONE]";
// ...
let response = event_mapper(event); // [DONE] passed to JSON parser → error!
return Some((response, (event_stream, event_mapper, done)));
```

## After

```rust
if event.data == "[DONE]" {
    return None; // clean stream termination
}
// ...
let response = event_mapper(event);
return Some((response, (event_stream, event_mapper)));
```