### PR TITLE
fix(responses): default missing InputImageContent.detail during deserialization

### DIFF
--- a/async-openai/src/types/responses/response.rs
+++ b/async-openai/src/types/responses/response.rs
@@ -703,7 +703,8 @@ pub struct InputTextContent {
 #[builder(build_fn(error = "OpenAIError"))]
 pub struct InputImageContent {
     /// The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`.
-    /// Defaults to `auto`.
+    /// Defaults to `auto` when omitted in JSON input.
+    #[serde(default)]
     pub detail: ImageDetail,
     /// The ID of the file to be sent to the model.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/async-openai/tests/responses_input_item_serde.rs
+++ b/async-openai/tests/responses_input_item_serde.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "response-types")]
 
 use async_openai::types::responses::{
-    EasyInputContent, InputItem, MessageType, Role, WebSearchApproximateLocation,
-    WebSearchApproximateLocationType,
+    EasyInputContent, ImageDetail, InputContent, InputItem, InputRole, Item, MessageItem,
+    MessageType, Role, WebSearchApproximateLocation, WebSearchApproximateLocationType,
 };
 use serde_json::json;
 
@@ -61,4 +61,79 @@ fn web_search_approximate_location_without_type_defaults_and_serializes_canonica
             "country": "US"
         })
     );
+}
+
+#[test]
+fn input_item_easy_message_multimodal_without_detail_defaults_and_serializes_canonically() {
+    let input_item: InputItem = serde_json::from_value(json!({
+        "role": "user",
+        "content": [
+            {"type": "input_text", "text": "describe this"},
+            {"type": "input_image", "image_url": "https://example.com/cat.png"}
+        ]
+    }))
+    .expect("deserialize easy input image without detail");
+
+    match &input_item {
+        InputItem::EasyMessage(msg) => {
+            assert_eq!(msg.r#type, MessageType::Message);
+            assert_eq!(msg.role, Role::User);
+            match &msg.content {
+                EasyInputContent::ContentList(parts) => {
+                    assert_eq!(parts.len(), 2);
+                    match &parts[1] {
+                        InputContent::InputImage(img) => {
+                            assert_eq!(img.detail, ImageDetail::Auto);
+                            assert_eq!(
+                                img.image_url.as_deref(),
+                                Some("https://example.com/cat.png")
+                            );
+                            assert_eq!(img.file_id, None);
+                        }
+                        other => panic!("expected InputImage, got {other:?}"),
+                    }
+                }
+                other => panic!("expected ContentList, got {other:?}"),
+            }
+        }
+        other => panic!("expected EasyMessage, got {other:?}"),
+    }
+
+    let serialized = serde_json::to_value(&input_item).expect("serialize input item");
+    assert_eq!(
+        serialized,
+        json!({
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "describe this"},
+                {"type": "input_image", "detail": "auto", "image_url": "https://example.com/cat.png"}
+            ]
+        })
+    );
+}
+
+#[test]
+fn input_item_strict_message_multimodal_without_detail_defaults() {
+    let input_item: InputItem = serde_json::from_value(json!({
+        "type": "message",
+        "role": "user",
+        "content": [
+            {"type": "input_image", "image_url": "https://example.com/cat.png"}
+        ]
+    }))
+    .expect("deserialize strict input image without detail");
+
+    match &input_item {
+        InputItem::Item(Item::Message(MessageItem::Input(msg))) => {
+            assert_eq!(msg.role, InputRole::User);
+            match &msg.content[0] {
+                InputContent::InputImage(img) => {
+                    assert_eq!(img.detail, ImageDetail::Auto);
+                }
+                other => panic!("expected InputImage, got {other:?}"),
+            }
+        }
+        other => panic!("expected Item::Message(Input), got {other:?}"),
+    }
 }


### PR DESCRIPTION
- default `InputImageContent.detail` to `auto` when missing in JSON input
- add focused response-types integration tests covering both the
  `EasyMessage` and strict `Item::Message(Input::User)` deserialization paths

Closes #545.

`InputImageContent.detail` is documented as defaulting to `auto`, but without
`#[serde(default)]` any spec-compliant payload that omits `detail` (per
openai-python's `ResponseInputImageParam`, which marks `detail`
`Optional[Literal["low","high","auto"]]`) fails to deserialize. Because
`InputItem` is `#[serde(untagged)]`, the single missing-field error rolls up
to `data did not match any variant of untagged enum InputItem`, which is
what spec-compliant clients hit in practice (full traceback in #545).

This mirrors the precedent set by #527 (`EasyInputMessage.r#type`,
`WebSearchApproximateLocation.r#type`) and uses the same test file
(`tests/responses_input_item_serde.rs`).

`ImageDetail` already derives `Default` with `#[default] Auto`, so the
fix is a single `#[serde(default)]` attribute — no `Default` impl needed.

## Verification

- `cargo test -p async-openai --test responses_input_item_serde --features response-types` → 4 passed (2 pre-existing + 2 new)
- `cargo fmt --check` → clean
- `cargo clippy -p async-openai --features response-types --tests -- -D warnings` → clean
- End-to-end repro: against released v0.38.1 from crates.io, the payload below errors with `data did not match any variant of untagged enum InputItem`; against this branch the same payload deserializes successfully with `detail` defaulted to `ImageDetail::Auto`.

```json
{
  "role": "user",
  "content": [
    {"type": "input_text", "text": "describe this"},
    {"type": "input_image", "image_url": "https://example.com/cat.png"}
  ]
}
```

Refs:
- openapi.documented.yml: `ResponseInputImage` (type required; `image_url` / `file_id` / `detail` all optional)
- openai-python: [`src/openai/types/responses/response_input_image_param.py`](https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response_input_image_param.py) — `detail: Optional[Literal["low", "high", "auto"]]`
- openai-node: `src/resources/responses/responses.ts` — `detail?: 'low' | 'high' | 'auto'`
- Prior fix in same spirit: #527