### PR TITLE
fix: Make `action` optional in `response.output_item.added`

### DIFF
--- a/async-openai/src/types/responses/response.rs
+++ b/async-openai/src/types/responses/response.rs
@@ -2034,7 +2034,12 @@ pub enum WebSearchToolCallAction {
 pub struct WebSearchToolCall {
     /// An object describing the specific action taken in this web search call. Includes
     /// details on how the model used the web (search, open_page, find, find_in_page).
-    pub action: WebSearchToolCallAction,
+    ///
+    /// This is optional because `response.output_item.added` events can include
+    /// in-progress web search calls before OpenAI has populated the action.
+    /// See <https://github.com/64bit/async-openai/issues/548>.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<WebSearchToolCallAction>,
     /// The unique ID of the web search tool call.
     pub id: String,
     /// The status of the web search tool call.

--- a/async-openai/tests/responses_input_item_serde.rs
+++ b/async-openai/tests/responses_input_item_serde.rs
@@ -2,7 +2,8 @@
 
 use async_openai::types::responses::{
     EasyInputContent, ImageDetail, InputContent, InputItem, InputRole, Item, MessageItem,
-    MessageType, Role, WebSearchApproximateLocation, WebSearchApproximateLocationType,
+    MessageType, OutputItem, ResponseStreamEvent, Role, WebSearchApproximateLocation,
+    WebSearchApproximateLocationType, WebSearchToolCallStatus,
 };
 use serde_json::json;
 

--- a/async-openai/tests/responses_input_item_serde.rs
+++ b/async-openai/tests/responses_input_item_serde.rs
@@ -64,6 +64,33 @@ fn web_search_approximate_location_without_type_defaults_and_serializes_canonica
 }
 
 #[test]
+fn response_output_item_added_web_search_call_without_action_deserializes() {
+    let event: ResponseStreamEvent = serde_json::from_value(json!({
+        "type": "response.output_item.added",
+        "sequence_number": 2,
+        "output_index": 0,
+        "item": {
+            "id": "ws_123",
+            "type": "web_search_call",
+            "status": "in_progress"
+        }
+    }))
+    .expect("deserialize in-progress web search call without action");
+
+    match event {
+        ResponseStreamEvent::ResponseOutputItemAdded(event) => match event.item {
+            OutputItem::WebSearchCall(call) => {
+                assert_eq!(call.id, "ws_123");
+                assert_eq!(call.status, WebSearchToolCallStatus::InProgress);
+                assert_eq!(call.action, None);
+            }
+            other => panic!("expected WebSearchCall, got {other:?}"),
+        },
+        other => panic!("expected ResponseOutputItemAdded, got {other:?}"),
+    }
+}
+
+#[test]
 fn input_item_easy_message_multimodal_without_detail_defaults_and_serializes_canonically() {
     let input_item: InputItem = serde_json::from_value(json!({
         "role": "user",


### PR DESCRIPTION
This makes the `action` field of the `WebSearchToolCall` optional to workaround an OpenAI bug.

Fixes https://github.com/64bit/async-openai/issues/548