### PR TITLE
Return http status code for ApiError

### DIFF
--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -12,7 +12,7 @@ use crate::error::StreamError;
 use crate::executor::TowerExecutor;
 use crate::{
     config::{Config, OpenAIConfig},
-    error::{map_deserialization_error, ApiError, OpenAIError, WrappedError},
+    error::{map_deserialization_error, ApiError, ApiErrorResponse, OpenAIError, WrappedError},
     executor::{HttpRequestFactory, ReqwestExecutor, SharedExecutor},
     traits::AsyncTryFrom,
     RequestOptions,
@@ -732,11 +732,14 @@ async fn read_response(response: Response) -> Result<(Bytes, HeaderMap), OpenAIE
         // OpenAI does not guarantee server errors are returned as JSON so we cannot deserialize them.
         let message: String = String::from_utf8_lossy(&bytes).into_owned();
         tracing::warn!("Server error: {status} - {message}");
-        return Err(OpenAIError::ApiError(ApiError {
-            message,
-            r#type: None,
-            param: None,
-            code: None,
+        return Err(OpenAIError::ApiError(ApiErrorResponse {
+            status_code: status,
+            api_error: ApiError {
+                message,
+                r#type: None,
+                param: None,
+                code: None,
+            },
         }));
     }
 
@@ -745,7 +748,10 @@ async fn read_response(response: Response) -> Result<(Bytes, HeaderMap), OpenAIE
         let wrapped_error: WrappedError = serde_json::from_slice(bytes.as_ref())
             .map_err(|e| map_deserialization_error(e, bytes.as_ref()))?;
 
-        return Err(OpenAIError::ApiError(wrapped_error.error));
+        return Err(OpenAIError::ApiError(ApiErrorResponse {
+            status_code: status,
+            api_error: wrapped_error.error,
+        }));
     }
 
     Ok((bytes, headers))

--- a/async-openai/src/error.rs
+++ b/async-openai/src/error.rs
@@ -114,7 +114,9 @@ impl std::error::Error for ApiError {}
 #[cfg(feature = "_api")]
 #[derive(Debug, Clone)]
 pub struct ApiErrorResponse {
+    /// HTTP status code
     pub status_code: reqwest::StatusCode,
+    /// Parsed error from response 
     pub api_error: ApiError,
 }
 

--- a/async-openai/src/error.rs
+++ b/async-openai/src/error.rs
@@ -116,7 +116,7 @@ impl std::error::Error for ApiError {}
 pub struct ApiErrorResponse {
     /// HTTP status code
     pub status_code: reqwest::StatusCode,
-    /// Parsed error from response 
+    /// Parsed error from response
     pub api_error: ApiError,
 }
 

--- a/async-openai/src/error.rs
+++ b/async-openai/src/error.rs
@@ -8,9 +8,10 @@ pub enum OpenAIError {
     /// Underlying error from reqwest library after an API call was made
     #[error("http error: {0}")]
     Reqwest(#[from] reqwest::Error),
-    /// OpenAI returns error object with details of API call failure
+    /// OpenAI returns error object with details of API call failure, along
+    /// with the HTTP status code from the response.
     #[error("{0}")]
-    ApiError(ApiError),
+    ApiError(ApiErrorResponse),
     /// Error when a response cannot be deserialized into a Rust type
     #[error("failed to deserialize api response: error:{0} content:{1}")]
     JSONDeserialize(serde_json::Error, String),
@@ -108,6 +109,24 @@ impl std::fmt::Display for ApiError {
 }
 
 impl std::error::Error for ApiError {}
+
+/// `ApiError` paired with the HTTP status code from the response.
+#[cfg(feature = "_api")]
+#[derive(Debug, Clone)]
+pub struct ApiErrorResponse {
+    pub status_code: reqwest::StatusCode,
+    pub api_error: ApiError,
+}
+
+#[cfg(feature = "_api")]
+impl std::fmt::Display for ApiErrorResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {}", self.status_code, self.api_error)
+    }
+}
+
+#[cfg(feature = "_api")]
+impl std::error::Error for ApiErrorResponse {}
 
 /// Wrapper to deserialize the error object nested in "error" JSON key
 #[derive(Debug, Deserialize, Serialize)]

--- a/async-openai/src/middleware/retry/openai.rs
+++ b/async-openai/src/middleware/retry/openai.rs
@@ -3,7 +3,7 @@ use std::{future::Future, pin::Pin, time::Duration};
 use reqwest::{header::HeaderMap, Response};
 
 use crate::{
-    error::{OpenAIError, WrappedError},
+    error::{ApiErrorResponse, OpenAIError, WrappedError},
     executor::HttpRequestFactory,
 };
 
@@ -165,6 +165,7 @@ where
         let (final_result, headers, retry_after) = match result {
             Ok(response) if response.status().is_success() => return Ok(response),
             Ok(response) if response.status().as_u16() == 429 => {
+                let status_code = response.status();
                 let headers = response.headers().clone();
                 let retry_after = retry_after(&headers);
                 let bytes = match response.bytes().await {
@@ -177,10 +178,16 @@ where
                         // 429 and insufficient_quota are treated as permanent error.
                         // https://developers.openai.com/api/docs/guides/error-codes
                         if wrapped_error.error.r#type.as_deref() == Some(INSUFFICIENT_QUOTA) {
-                            return Err(OpenAIError::ApiError(wrapped_error.error));
+                            return Err(OpenAIError::ApiError(ApiErrorResponse {
+                                status_code,
+                                api_error: wrapped_error.error,
+                            }));
                         }
 
-                        OpenAIError::ApiError(wrapped_error.error)
+                        OpenAIError::ApiError(ApiErrorResponse {
+                            status_code,
+                            api_error: wrapped_error.error,
+                        })
                     }
                     Err(error) => {
                         return Err(OpenAIError::JSONDeserialize(


### PR DESCRIPTION
Preserves the HTTP `StatusCode` from non-2xx responses by changing `OpenAIError::ApiError` to wrap a new `ApiErrorResponse { status_code, api_error }` struct. This lets callers distinguish 400 / 404 / 5xx without pattern-matching on `ApiError.r#type` strings — the original motivation in #549, e.g. for gateways that proxy to non-OpenAI-compatible upstreams.

  Implements option (2) from the issue discussion (the maintainer's preferred shape — wrapping in a struct rather than a struct-variant, so a single value can be passed/extended later).

  This is a **breaking change** for callers that pattern-match on `OpenAIError::ApiError(_)`: the inner type is now `ApiErrorResponse` rather than `ApiError`, accessed via `.api_error`. Per the issue thread, a dedicated minor release was suggested.

  Closes #549.

  ## Changes
  - `error.rs`: add `ApiErrorResponse` (status + api_error, with `Display`/`Error` impls); change variant to `ApiError(ApiErrorResponse)`. The existing `ApiError` struct and its JSON-body `Display` are untouched.
  - `client.rs` `read_response`: wrap both 5xx and non-2xx construction sites with the captured `status`.
  - `middleware/retry/openai.rs`: capture `status_code` before consuming the response body in the 429 path; wrap both the transient and `insufficient_quota` error returns.