### PR TITLE
fix(responses): default ResponseTextParam.format during deserialization

### DIFF
--- a/async-openai/src/types/responses/response.rs
+++ b/async-openai/src/types/responses/response.rs
@@ -1139,6 +1139,7 @@ pub struct ResponseTextParam {
     /// Setting to `{ "type": "json_object" }` enables the older JSON mode, which
     /// ensures the message the model generates is valid JSON. Using `json_schema`
     /// is preferred for models that support it.
+    #[serde(default)]
     pub format: TextResponseFormatConfiguration,
 
     /// Constrains the verbosity of the model's response. Lower values will result in
@@ -1149,10 +1150,11 @@ pub struct ResponseTextParam {
     pub verbosity: Option<Verbosity>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TextResponseFormatConfiguration {
     /// Default response format. Used to generate text responses.
+    #[default]
     Text,
     /// JSON object response format. An older method of generating JSON responses.
     /// Using `json_schema` is recommended for models that support it.

--- a/async-openai/tests/responses_input_item_serde.rs
+++ b/async-openai/tests/responses_input_item_serde.rs
@@ -2,7 +2,8 @@
 
 use async_openai::types::responses::{
     EasyInputContent, ImageDetail, InputContent, InputItem, InputRole, Item, MessageItem,
-    MessageType, OutputItem, ResponseStreamEvent, Role, WebSearchApproximateLocation,
+    MessageType, OutputItem, ResponseStreamEvent, ResponseTextParam, Role,
+    TextResponseFormatConfiguration, WebSearchApproximateLocation,
     WebSearchApproximateLocationType, WebSearchToolCallStatus,
 };
 use serde_json::json;
@@ -139,6 +140,15 @@ fn input_item_easy_message_multimodal_without_detail_defaults_and_serializes_can
             ]
         })
     );
+}
+
+#[test]
+fn response_text_param_without_format_defaults_to_text() {
+    let param: ResponseTextParam =
+        serde_json::from_value(json!({})).expect("deserialize ResponseTextParam without format");
+
+    assert_eq!(param.format, TextResponseFormatConfiguration::Text);
+    assert_eq!(param.verbosity, None);
 }
 
 #[test]


### PR DESCRIPTION
Closes #551