### PR TITLE
fix: make schema required field in ResponseFormatJsonSchema

### DIFF
--- a/async-openai/src/types/shared/response_format.rs
+++ b/async-openai/src/types/shared/response_format.rs
@@ -22,8 +22,7 @@ pub struct ResponseFormatJsonSchema {
     pub name: String,
     /// The schema for the response format, described as a JSON Schema object.
     /// Learn how to build JSON schemas [here](https://json-schema.org/).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub schema: Option<serde_json::Value>,
+    pub schema: serde_json::Value,
     /// Whether to enable strict schema adherence when generating the output.
     /// If set to true, the model will always follow the exact schema defined
     /// in the `schema` field. Only a subset of JSON Schema is supported when

--- a/examples/responses-structured-outputs/src/main.rs
+++ b/examples/responses-structured-outputs/src/main.rs
@@ -47,7 +47,7 @@ async fn chain_of_thought(client: &Client<OpenAIConfig>) -> Result<(), Box<dyn E
                 "A step-by-step reasoning process for solving math problems".to_string(),
             ),
             name: "math_reasoning".to_string(),
-            schema: Some(schema),
+            schema,
             strict: Some(true),
         })
         .input(vec![
@@ -107,7 +107,7 @@ async fn structured_data_extraction(client: &Client<OpenAIConfig>) -> Result<(),
         .text(ResponseFormatJsonSchema {
             description: Some("Extract structured information from text".to_string()),
             name: "person_info".to_string(),
-            schema: Some(schema),
+            schema,
             strict: Some(true),
         })
         .input(vec![
@@ -192,7 +192,7 @@ async fn ui_generation(client: &Client<OpenAIConfig>) -> Result<(), Box<dyn Erro
         .text(ResponseFormatJsonSchema {
             description: Some("Generate HTML and CSS code for UI components".to_string()),
             name: "ui_component".to_string(),
-            schema: Some(schema),
+            schema,
             strict: Some(true),
         })
         .input(vec![
@@ -257,7 +257,7 @@ async fn moderation(client: &Client<OpenAIConfig>) -> Result<(), Box<dyn Error>>
         .text(ResponseFormatJsonSchema {
             description: Some("Analyze content for policy violations and provide structured moderation results".to_string()),
             name: "moderation_result".to_string(),
-            schema: Some(schema),
+            schema,
             strict: Some(true),
         })
         .input(vec![
@@ -320,7 +320,7 @@ async fn streaming_structured_output(client: &Client<OpenAIConfig>) -> Result<()
         .text(ResponseFormatJsonSchema {
             description: Some("Extract entities from the input text".to_string()),
             name: "entities".to_string(),
-            schema: Some(schema),
+            schema,
             strict: Some(true),
         })
         .input(vec![

--- a/examples/structured-outputs-schemars/src/main.rs
+++ b/examples/structured-outputs-schemars/src/main.rs
@@ -34,7 +34,7 @@ pub async fn structured_output<T: serde::Serialize + DeserializeOwned + JsonSche
         json_schema: ResponseFormatJsonSchema {
             description: None,
             name: "math_reasoning".into(),
-            schema: Some(schema_value),
+            schema: schema_value,
             strict: Some(true),
         },
     };

--- a/examples/structured-outputs/src/main.rs
+++ b/examples/structured-outputs/src/main.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         json_schema: ResponseFormatJsonSchema {
             description: None,
             name: "math_reasoning".into(),
-            schema: Some(schema),
+            schema,
             strict: Some(true),
         },
     };


### PR DESCRIPTION
Verified that at runtime OpenAI API expect it to be present, even though the spec says its optional. 

The official openai-python requires it too.

Closes #534 