### PR TITLE
feat: forward reqwest's rustls-no-provider feature

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -118,3 +118,55 @@ jobs:
         env:
           RUSTFLAGS: "-D warnings"
         run: cargo build --no-default-features --features ${{ matrix.feature }},middleware --verbose
+
+  tls-features:
+    name: TLS Feature - ${{ matrix.feature }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        feature: [rustls, rustls-no-provider, native-tls, native-tls-vendored]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Build with TLS feature ${{ matrix.feature }}
+        env:
+          RUSTFLAGS: "-D warnings"
+        run: cargo build -p async-openai --no-default-features --features ${{ matrix.feature }},chat-completion --verbose
+
+      # -e normal,build matches what `cargo build` actually compiles.
+      # `--prefix none` keeps the
+      # output as one crate per line so the grep below can anchor on the
+      # crate name precisely.
+      - name: Verify aws-lc-rs is absent under ${{ matrix.feature }}
+        if: matrix.feature != 'rustls'
+        run: |
+          tree=$(cargo tree -p async-openai --no-default-features \
+            --features ${{ matrix.feature }},chat-completion \
+            -e normal,build --prefix none)
+          if echo "$tree" | grep -qE '^aws-lc-rs( |$)'; then
+            echo "ERROR: aws-lc-rs was pulled in by ${{ matrix.feature }}:"
+            echo "$tree" | grep -E '^aws-lc'
+            exit 1
+          fi
+          echo "OK: no aws-lc-rs in dependency tree"
+
+      - name: Verify aws-lc-rs is present under rustls (sanity check)
+        if: matrix.feature == 'rustls'
+        run: |
+          tree=$(cargo tree -p async-openai --no-default-features \
+            --features rustls,chat-completion \
+            -e normal,build --prefix none)
+          if ! echo "$tree" | grep -qE '^aws-lc-rs( |$)'; then
+            echo "ERROR: expected aws-lc-rs to be pulled in by rustls feature, but it was not"
+            exit 1
+          fi
+          echo "OK: aws-lc-rs present in dependency tree"

--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -16,6 +16,8 @@ repository = "https://github.com/64bit/async-openai"
 default = ["rustls"]
 # Enable rustls for TLS support (uses rustls-platform-verifier for roots in reqwest 0.13)
 rustls = ["dep:reqwest", "reqwest/rustls"]
+# Enable rustls without a crypto provider; consumer must install one (e.g. ring or aws-lc-rs)
+rustls-no-provider = ["dep:reqwest", "reqwest/rustls-no-provider"]
 # Enable native-tls for TLS support
 native-tls = ["dep:reqwest", "reqwest/native-tls"]
 # Remove dependency on OpenSSL

--- a/async-openai/README.md
+++ b/async-openai/README.md
@@ -226,6 +226,17 @@ There are granular feature flags like `response-types`, `chat-completion-types`,
 
 These granular types are enabled when the corresponding API feature is enabled - for example `responses` will enable `response-types`.
 
+## TLS backends
+
+The crate exposes the underlying `reqwest` TLS options as Cargo features. Pick exactly one; disable default features when choosing anything other than `rustls`.
+
+| Feature | TLS implementation | Crypto provider | Notes |
+| --- | --- | --- | --- |
+| `rustls` (default) | `rustls` + `rustls-platform-verifier` roots | `aws-lc-rs` bundled | Works out of the box. |
+| `rustls-no-provider` | `rustls` + `rustls-platform-verifier` roots | **None** — install your own | Use this to pick `ring` (or share a provider across your tree). Call e.g. `rustls::crypto::ring::default_provider().install_default().unwrap();` at the start of `main`. |
+| `native-tls` | System TLS | n/a | OpenSSL on Linux, Secure Transport on macOS, SChannel on Windows. |
+| `native-tls-vendored` | System TLS, vendored OpenSSL | n/a | Statically links a bundled OpenSSL build. |
+
 ## Webhooks
 
 Support for webhook includes event types, signature verification, and building webhook events from payloads.


### PR DESCRIPTION
This closes https://github.com/64bit/async-openai/issues/547

This adds a new feature `rustls-no-provider` which will forward to reqwest. This allows users to provide their own rustls crypto provider.

This contains additions to the CI jobs to prevent regressions in the future.