### PR TITLE
updated eventsource-stream to eventsource-stream2

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -180,7 +180,7 @@ secrecy = { version = "0.10", features = ["serde"], optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
 url = { version = "2.5", optional = true }
 tower = { version = "0.5", features = ["limit", "retry", "timeout", "util"], optional = true }
-eventsource-stream = { version = "0.2", optional = true }
+eventsource-stream = { package = "eventsource-stream2", version = "0.3", optional = true }
 ## For Webhook signature verification
 hmac = { version = "0.12", optional = true, default-features = false}
 sha2 = { version = "0.10", optional = true, default-features = false }

--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -180,7 +180,7 @@ secrecy = { version = "0.10", features = ["serde"], optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
 url = { version = "2.5", optional = true }
 tower = { version = "0.5", features = ["limit", "retry", "timeout", "util"], optional = true }
-eventsource-stream = { package = "eventsource-stream2", version = "0.3", optional = true }
+eventsource-stream = { package = "eventsource-stream2", version = "0.4", optional = true }
 ## For Webhook signature verification
 hmac = { version = "0.12", optional = true, default-features = false}
 sha2 = { version = "0.10", optional = true, default-features = false }


### PR DESCRIPTION
eventsource-stream has not been updated since February of 2022. I ported my parser from `sseer` to `eventsource-stream` and opened a [pr](https://github.com/jpopesculian/eventsource-stream/pull/12) that fixes a performance issue, after emailing Julian a few months back I got no reply so I decided to fork it instead.

eventsource-stream2 is nearly exactly the same just with a faster parser and one less error variant since the parser can never actually error, so for async-openai it's literally just a drop-in replacement as you don't depend on the `EventStreamError::Parser` variant I removed. The change is so drop-in all I had to do was change the Cargo.toml lol.

In terms of real world performance uplift it wont be much but it should improve the worst case of large SSE lines, in some benchmarks I found a 50x uplift in the best case of a 1024 byte line with the average uplift being closer to 4x.