### PR TITLE
fix(types): omit ImageUrl.detail when None

### DIFF
--- a/async-openai/src/types/shared/image_url.rs
+++ b/async-openai/src/types/shared/image_url.rs
@@ -14,5 +14,6 @@ pub struct ImageUrl {
     /// Either a URL of the image or the base64 encoded image data.
     pub url: String,
     /// Specifies the detail level of the image. Learn more in the [Vision guide](https://platform.openai.com/docs/guides/vision/low-or-high-fidelity-image-understanding).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<ImageDetail>,
 }


### PR DESCRIPTION
## Problem

`ImageUrl.detail` (`async-openai/src/types/shared/image_url.rs`) is an `Option<ImageDetail>` with no `skip_serializing_if`, so when it is `None` the request body carries an explicit `"detail": null`:

```json
{ "type": "image_url", "image_url": { "url": "data:image/png;base64,…", "detail": null } }
```

The official OpenAI API tolerates this, but stricter OpenAI-compatible gateways validate `detail` as a `Literal['auto','low','high']` and reject the explicit `null` with an HTTP 400:

```
1 validation error for ChatCompletionContentPartImageParam
image_url.detail
  Input should be 'auto', 'low' or 'high' [type=literal_error, input_value=None, input_type=NoneType]
```

Since `detail` is an optional field, the correct wire representation when unset is to omit it entirely (the server then applies its own default, `auto`).

## Fix

Add `#[serde(skip_serializing_if = "Option::is_none")]` to `ImageUrl.detail` so the field is omitted when `None`. No behavioural change against the OpenAI API itself; it just stops emitting an explicit `null` that some compatible backends reject.

```rust
#[serde(skip_serializing_if = "Option::is_none")]
pub detail: Option<ImageDetail>,
```

Deserialization is unaffected (the field already round-trips), and explicit values (`Some(Auto/Low/High)`) still serialize as before.