### PR TITLE
feat: add RateLimitLayer middleware

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -52,6 +52,7 @@ assistant = ["assistant-types", "_api", ]
 administration = ["administration-types", "_api"]
 completions = ["completion-types", "_api"]
 middleware = ["dep:tower", "_api"]
+rate-limit = ["dep:governor", "middleware"]
 
 # Type feature flags - these enable only the types
 response-types = ["dep:derive_builder"]
@@ -132,6 +133,7 @@ full = [
     "types",
     "byot",
     "middleware",
+    "rate-limit",
 ]
 
 # Internal feature to enable API dependencies
@@ -180,6 +182,7 @@ secrecy = { version = "0.10", features = ["serde"], optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
 url = { version = "2.5", optional = true }
 tower = { version = "0.5", features = ["limit", "retry", "timeout", "util"], optional = true }
+governor = { version = "0.8", optional = true, default-features = false, features = ["std"] }
 eventsource-stream = { version = "0.2", optional = true }
 ## For Webhook signature verification
 hmac = { version = "0.12", optional = true, default-features = false}
@@ -197,6 +200,7 @@ tokio-tungstenite = { version = "0.28", optional = true, default-features = fals
 ## API WASM dependencies
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.3", features = ["wasm_js"] }
+governor = { version = "0.8", optional = true, default-features = false, features = ["std"] }
 
 [dev-dependencies]
 http = "1"

--- a/async-openai/MIDDLEWARE.md
+++ b/async-openai/MIDDLEWARE.md
@@ -91,6 +91,22 @@ Custom tower retry policies can call `middleware::retry::should_retry` to reuse 
 
 On native targets retries wait using `tokio::time::sleep`. On WASM retries are immediate.
 
+## Rate limit layer
+
+Enable the `rate-limit` feature to use `RateLimitLayer`.
+
+```rust
+use async_openai::middleware::{retry::OpenAIRetryLayer, ReqwestService};
+use async_openai::middleware::rate_limit::RateLimitLayer;
+
+let service = tower::ServiceBuilder::new()
+    .layer(OpenAIRetryLayer::default())
+    .layer(RateLimitLayer::per_minute(60))
+    .service(ReqwestService::new(reqwest::Client::new()));
+```
+
+`RateLimitLayer` should sit below `OpenAIRetryLayer` so retries are also throttled. On native targets, the layer provides local request-per-minute limiting and server-feedback backpressure from `x-ratelimit-remaining-requests` plus `x-ratelimit-reset-requests`. On WASM targets, it records local governor state but does not delay requests.
+
 ## Error Handling
 
 `OpenAIError::Boxed` is available only when the `middleware` feature is enabled.
@@ -103,5 +119,3 @@ Tower's `BoxError` converts into `OpenAIError::Boxed`, which is useful for gener
 ## Bring Your Own Types Interaction
 
 With the `byot` feature, generated `*_byot` methods keep the same minimal trait bounds with or without middleware. JSON request bodies are serialized before they enter the replayable middleware request factory.
-
-

--- a/async-openai/src/lib.rs
+++ b/async-openai/src/lib.rs
@@ -29,6 +29,7 @@
 //! ## Making requests
 //!
 //!```
+//!# #[cfg(feature = "responses")]
 //!# tokio_test::block_on(async {
 //! use async_openai::{Client, types::responses::{CreateResponseArgs}};
 //!
@@ -122,6 +123,7 @@
 //!
 //! For demonstration:
 //! ```
+//! # #[cfg(feature = "chat-completion")]
 //! # tokio_test::block_on(async {
 //! # use async_openai::Client;
 //! # use async_openai::traits::RequestOptionsBuilder;

--- a/async-openai/src/middleware/mod.rs
+++ b/async-openai/src/middleware/mod.rs
@@ -105,6 +105,35 @@
 //!
 //! On native targets retries wait using `tokio::time::sleep`. On WASM retries are immediate.
 //!
+//! ## Rate limit layer
+//!
+//! Enable the `rate-limit` feature to use [`rate_limit::RateLimitLayer`].
+//! Place it below [`retry::OpenAIRetryLayer`] so retry attempts also pass
+//! through the limiter:
+//!
+//! ```no_run
+//! # #[cfg(feature = "rate-limit")]
+//! # fn main() {
+//! # use async_openai::{Client, config::OpenAIConfig};
+//! # use async_openai::middleware::{ReqwestService, retry::OpenAIRetryLayer};
+//! # use async_openai::middleware::rate_limit::RateLimitLayer;
+//! let service = tower::ServiceBuilder::new()
+//!     .layer(OpenAIRetryLayer::default())
+//!     .layer(RateLimitLayer::per_minute(60))
+//!     .service(ReqwestService::new(reqwest::Client::new()));
+//!
+//! let client = Client::with_config(OpenAIConfig::default())
+//!     .with_http_service(service);
+//! # }
+//! # #[cfg(not(feature = "rate-limit"))]
+//! # fn main() {}
+//! ```
+//!
+//! On native targets, the layer limits request RPM locally and applies
+//! server-feedback backpressure when `x-ratelimit-remaining-requests`
+//! reaches zero and `x-ratelimit-reset-requests` is parseable. On WASM
+//! targets, it records local governor state but does not delay requests.
+//!
 //! ## Error Handling
 //!
 //! `OpenAIError::Boxed` is available only when the `middleware` feature is enabled.
@@ -119,6 +148,10 @@
 //! With the `byot` feature, generated `*_byot` methods keep the same minimal
 //! trait bounds with or without middleware. JSON request bodies are serialized
 //! before they enter the replayable middleware request factory.
+
+/// Request rate limiting middleware.
+#[cfg(feature = "rate-limit")]
+pub mod rate_limit;
 
 /// Retry layers and policies for middleware.
 pub mod retry {

--- a/async-openai/src/middleware/rate_limit/mod.rs
+++ b/async-openai/src/middleware/rate_limit/mod.rs
@@ -1,0 +1,697 @@
+//! Client-side request rate limiting middleware.
+
+use std::future::Future;
+use std::num::NonZeroU32;
+use std::pin::Pin;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+use std::task::{Context, Poll};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use governor::{clock::Clock, DefaultDirectRateLimiter, Quota, RateLimiter};
+use reqwest::Response;
+
+use crate::{error::OpenAIError, executor::HttpRequestFactory};
+
+#[cfg(not(target_family = "wasm"))]
+type RateLimitFuture =
+    Pin<Box<dyn Future<Output = Result<Response, OpenAIError>> + Send + 'static>>;
+#[cfg(target_family = "wasm")]
+type RateLimitFuture = Pin<Box<dyn Future<Output = Result<Response, OpenAIError>> + 'static>>;
+
+/// Tower layer for client-side request rate limiting.
+#[derive(Clone, Debug)]
+pub struct RateLimitLayer {
+    limiter: Arc<DefaultDirectRateLimiter>,
+    backpressure: Arc<ServerBackpressure>,
+}
+
+impl RateLimitLayer {
+    /// Create a layer that allows at most `rpm` requests per minute.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `rpm` is zero.
+    pub fn per_minute(rpm: u32) -> Self {
+        let rpm = NonZeroU32::new(rpm).expect("rpm must be greater than zero");
+        Self::new(Quota::per_minute(rpm))
+    }
+
+    #[cfg(test)]
+    fn per_second_for_tests(rps: u32) -> Self {
+        let rps = NonZeroU32::new(rps).expect("rps must be greater than zero");
+        Self::new(Quota::per_second(rps))
+    }
+
+    fn new(quota: Quota) -> Self {
+        Self {
+            limiter: Arc::new(RateLimiter::direct(quota)),
+            backpressure: Arc::new(ServerBackpressure::default()),
+        }
+    }
+}
+
+impl<S> tower::Layer<S> for RateLimitLayer {
+    type Service = RateLimitService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RateLimitService {
+            inner,
+            limiter: self.limiter.clone(),
+            backpressure: self.backpressure.clone(),
+            #[cfg(not(target_family = "wasm"))]
+            delay: None,
+            #[cfg(not(target_family = "wasm"))]
+            delay_deadline_ms: 0,
+        }
+    }
+}
+
+/// Tower service produced by [`RateLimitLayer`].
+pub struct RateLimitService<S> {
+    inner: S,
+    limiter: Arc<DefaultDirectRateLimiter>,
+    backpressure: Arc<ServerBackpressure>,
+    #[cfg(not(target_family = "wasm"))]
+    delay: Option<Pin<Box<tokio::time::Sleep>>>,
+    #[cfg(not(target_family = "wasm"))]
+    delay_deadline_ms: u64,
+}
+
+impl<S> Clone for RateLimitService<S>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            limiter: self.limiter.clone(),
+            backpressure: self.backpressure.clone(),
+            #[cfg(not(target_family = "wasm"))]
+            delay: None,
+            #[cfg(not(target_family = "wasm"))]
+            delay_deadline_ms: 0,
+        }
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl<S> RateLimitService<S> {
+    fn poll_delay_until(&mut self, cx: &mut Context<'_>, deadline_ms: u64) -> Poll<()> {
+        if self.delay_deadline_ms != deadline_ms {
+            let wait_ms = deadline_ms.saturating_sub(now_millis());
+            self.delay = Some(Box::pin(tokio::time::sleep(Duration::from_millis(wait_ms))));
+            self.delay_deadline_ms = deadline_ms;
+        }
+
+        let Some(delay) = self.delay.as_mut() else {
+            return Poll::Ready(());
+        };
+
+        match delay.as_mut().poll(cx) {
+            Poll::Ready(()) => {
+                self.delay = None;
+                self.delay_deadline_ms = 0;
+                Poll::Ready(())
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl<S> tower::Service<HttpRequestFactory> for RateLimitService<S>
+where
+    S: tower::Service<HttpRequestFactory, Response = Response, Error = OpenAIError>
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response;
+    type Error = OpenAIError;
+    type Future = RateLimitFuture;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        loop {
+            if let Some(reset_at) = self.backpressure.reset_at_millis() {
+                let now = now_millis();
+                if now < reset_at {
+                    if self.poll_delay_until(cx, reset_at).is_pending() {
+                        return Poll::Pending;
+                    }
+                    continue;
+                }
+
+                if self.backpressure.clear_if_deadline(reset_at).is_ok() {
+                    tracing::info!("rate limit request backpressure cleared at {reset_at}ms");
+                } else {
+                    continue;
+                }
+            }
+
+            match self.inner.poll_ready(cx) {
+                Poll::Ready(Ok(())) => {}
+                other => return other,
+            }
+
+            match self.limiter.check() {
+                Ok(()) => return Poll::Ready(Ok(())),
+                Err(not_until) => {
+                    let wait = not_until.wait_time_from(self.limiter.clock().now());
+                    let deadline = now_millis().saturating_add(duration_millis(wait));
+                    tracing::debug!("rate limit governor exhausted until {deadline}ms");
+
+                    if self.poll_delay_until(cx, deadline).is_pending() {
+                        return Poll::Pending;
+                    }
+                }
+            }
+        }
+    }
+
+    fn call(&mut self, request: HttpRequestFactory) -> Self::Future {
+        let backpressure = self.backpressure.clone();
+        let future = self.inner.call(request);
+
+        Box::pin(async move {
+            let response = future.await?;
+            update_backpressure_from_headers(response.headers(), &backpressure, now_millis());
+            Ok(response)
+        })
+    }
+}
+
+#[cfg(target_family = "wasm")]
+impl<S> tower::Service<HttpRequestFactory> for RateLimitService<S>
+where
+    S: tower::Service<HttpRequestFactory, Response = Response, Error = OpenAIError> + 'static,
+    S::Future: 'static,
+{
+    type Response = Response;
+    type Error = OpenAIError;
+    type Future = RateLimitFuture;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match self.inner.poll_ready(cx) {
+            Poll::Ready(Ok(())) => {}
+            other => return other,
+        }
+
+        if let Err(not_until) = self.limiter.check() {
+            tracing::debug!("rate limit governor exhausted until {not_until}");
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: HttpRequestFactory) -> Self::Future {
+        let future = self.inner.call(request);
+        Box::pin(async move { future.await })
+    }
+}
+
+#[derive(Debug, Default)]
+struct ServerBackpressure {
+    reset_at: AtomicU64,
+}
+
+impl ServerBackpressure {
+    fn reset_at_millis(&self) -> Option<u64> {
+        match self.reset_at.load(Ordering::Relaxed) {
+            0 => None,
+            value => Some(value),
+        }
+    }
+
+    fn update_deadline(&self, deadline_ms: u64) {
+        self.reset_at.fetch_max(deadline_ms, Ordering::Relaxed);
+    }
+
+    fn clear_if_deadline(&self, observed_deadline_ms: u64) -> Result<(), u64> {
+        self.reset_at.compare_exchange(
+            observed_deadline_ms,
+            0,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        )?;
+        Ok(())
+    }
+}
+
+fn now_millis() -> u64 {
+    duration_millis(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO),
+    )
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn parse_reset_duration(value: &str) -> Option<Duration> {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    let mut total = Duration::ZERO;
+    let mut saw_part = false;
+
+    while index < bytes.len() {
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+
+        if index == bytes.len() {
+            break;
+        }
+
+        let number_start = index;
+        while index < bytes.len() && bytes[index].is_ascii_digit() {
+            index += 1;
+        }
+
+        if number_start == index {
+            return None;
+        }
+
+        let number = value[number_start..index].parse::<u64>().ok()?;
+
+        let unit_start = index;
+        while index < bytes.len() && bytes[index].is_ascii_alphabetic() {
+            index += 1;
+        }
+
+        let unit = &value[unit_start..index];
+        let part = match unit {
+            "ms" => Duration::from_millis(number),
+            "s" => Duration::from_secs(number),
+            "m" => Duration::from_secs(number.checked_mul(60)?),
+            "h" => Duration::from_secs(number.checked_mul(60)?.checked_mul(60)?),
+            _ => return None,
+        };
+
+        total = total.checked_add(part)?;
+        saw_part = true;
+    }
+
+    saw_part.then_some(total)
+}
+
+fn update_backpressure_from_headers(
+    headers: &reqwest::header::HeaderMap,
+    backpressure: &ServerBackpressure,
+    now_ms: u64,
+) {
+    let Some(remaining_value) = headers.get(crate::retry::X_RATELIMIT_REMAINING_REQUESTS) else {
+        tracing::debug!("rate limit remaining requests header is missing");
+        return;
+    };
+
+    let Some(remaining) = remaining_value
+        .to_str()
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+    else {
+        tracing::debug!("rate limit remaining requests header is invalid");
+        return;
+    };
+
+    if remaining != 0 {
+        tracing::debug!("rate limit remaining requests is not exhausted");
+        return;
+    }
+
+    let Some(reset) = headers
+        .get(crate::retry::X_RATELIMIT_RESET_REQUESTS)
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_reset_duration)
+    else {
+        tracing::debug!("rate limit reset requests header is missing or invalid");
+        return;
+    };
+
+    let reset_ms = duration_millis(reset);
+    let deadline = now_ms.saturating_add(reset_ms);
+    backpressure.update_deadline(deadline);
+    tracing::warn!("rate limit request backpressure active until {deadline}ms");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::Response as HttpResponse;
+    use std::sync::atomic::AtomicUsize;
+    use tower::{service_fn, Layer, Service, ServiceBuilder, ServiceExt};
+
+    fn test_factory() -> HttpRequestFactory {
+        HttpRequestFactory::new(|| async {
+            Ok(reqwest::Request::new(
+                reqwest::Method::GET,
+                "http://example.test/models".parse().unwrap(),
+            ))
+        })
+    }
+
+    #[tokio::test]
+    async fn service_applies_backpressure_before_forwarding() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let service = RateLimitLayer::per_minute(60).layer({
+            let calls = calls.clone();
+            service_fn(move |_factory: HttpRequestFactory| {
+                let calls = calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, OpenAIError>(
+                        HttpResponse::builder()
+                            .status(200)
+                            .header(crate::retry::X_RATELIMIT_REMAINING_REQUESTS, "0")
+                            .header(crate::retry::X_RATELIMIT_RESET_REQUESTS, "25ms")
+                            .body(reqwest::Body::from("{}"))
+                            .unwrap()
+                            .into(),
+                    )
+                }
+            })
+        });
+
+        let mut service = service;
+        service
+            .ready()
+            .await
+            .unwrap()
+            .call(test_factory())
+            .await
+            .unwrap();
+
+        let started = std::time::Instant::now();
+        service
+            .ready()
+            .await
+            .unwrap()
+            .call(test_factory())
+            .await
+            .unwrap();
+
+        assert!(started.elapsed() >= Duration::from_millis(20));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn cloned_services_share_governor_bucket() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let service = RateLimitLayer::per_second_for_tests(1).layer({
+            let calls = calls.clone();
+            service_fn(move |_factory: HttpRequestFactory| {
+                let calls = calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, OpenAIError>(
+                        HttpResponse::builder()
+                            .status(200)
+                            .body(reqwest::Body::from("{}"))
+                            .unwrap()
+                            .into(),
+                    )
+                }
+            })
+        });
+
+        let mut first = service.clone();
+        let mut second = service;
+
+        first
+            .ready()
+            .await
+            .unwrap()
+            .call(test_factory())
+            .await
+            .unwrap();
+
+        let started = std::time::Instant::now();
+        second
+            .ready()
+            .await
+            .unwrap()
+            .call(test_factory())
+            .await
+            .unwrap();
+
+        assert!(started.elapsed() >= Duration::from_millis(900));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn pending_inner_readiness_does_not_consume_governor_permit() {
+        use futures::task::noop_waker_ref;
+
+        #[derive(Clone)]
+        struct PendingOnceService {
+            pending_once: bool,
+            calls: Arc<AtomicUsize>,
+        }
+
+        impl Service<HttpRequestFactory> for PendingOnceService {
+            type Response = reqwest::Response;
+            type Error = OpenAIError;
+            type Future =
+                Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+            fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                if self.pending_once {
+                    self.pending_once = false;
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, _req: HttpRequestFactory) -> Self::Future {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async {
+                    Ok(HttpResponse::builder()
+                        .status(200)
+                        .body(reqwest::Body::from("{}"))
+                        .unwrap()
+                        .into())
+                })
+            }
+        }
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut service = RateLimitLayer::per_second_for_tests(1).layer(PendingOnceService {
+            pending_once: true,
+            calls: calls.clone(),
+        });
+
+        let mut cx = Context::from_waker(noop_waker_ref());
+        assert!(matches!(service.poll_ready(&mut cx), Poll::Pending));
+
+        let started = std::time::Instant::now();
+        service
+            .ready()
+            .await
+            .unwrap()
+            .call(test_factory())
+            .await
+            .unwrap();
+
+        assert!(started.elapsed() < Duration::from_millis(200));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn retry_attempts_pass_through_rate_limiter() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let service = ServiceBuilder::new()
+            .layer(crate::retry::OpenAIRetryLayer::new(1))
+            .layer(RateLimitLayer::per_second_for_tests(1))
+            .service({
+                let calls = calls.clone();
+                service_fn(move |_factory: HttpRequestFactory| {
+                    let calls = calls.clone();
+                    async move {
+                        let attempt = calls.fetch_add(1, Ordering::SeqCst);
+                        let response = if attempt == 0 {
+                            HttpResponse::builder()
+                                .status(429)
+                                .header("content-type", "application/json")
+                                .body(reqwest::Body::from(
+                                    r#"{"error":{"message":"retry me","type":"rate_limit_error","param":null,"code":null}}"#,
+                                ))
+                                .unwrap()
+                        } else {
+                            HttpResponse::builder()
+                                .status(200)
+                                .body(reqwest::Body::from("{}"))
+                                .unwrap()
+                        };
+
+                        Ok::<_, OpenAIError>(response.into())
+                    }
+                })
+            });
+
+        let mut service = service;
+        let started = std::time::Instant::now();
+        service
+            .ready()
+            .await
+            .unwrap()
+            .call(test_factory())
+            .await
+            .unwrap();
+
+        assert!(started.elapsed() >= Duration::from_millis(900));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn parse_reset_duration_accepts_supported_units() {
+        assert_eq!(
+            parse_reset_duration("250ms"),
+            Some(Duration::from_millis(250))
+        );
+        assert_eq!(parse_reset_duration("6s"), Some(Duration::from_secs(6)));
+        assert_eq!(parse_reset_duration("1m30s"), Some(Duration::from_secs(90)));
+        assert_eq!(
+            parse_reset_duration("2h 1m 3s"),
+            Some(Duration::from_secs(7263))
+        );
+    }
+
+    #[test]
+    fn parse_reset_duration_rejects_invalid_values() {
+        assert_eq!(parse_reset_duration(""), None);
+        assert_eq!(parse_reset_duration("   "), None);
+        assert_eq!(parse_reset_duration("soon"), None);
+        assert_eq!(parse_reset_duration("1"), None);
+        assert_eq!(parse_reset_duration("1x"), None);
+        assert_eq!(parse_reset_duration("ms"), None);
+        assert_eq!(parse_reset_duration("18446744073709551615s1s"), None);
+        assert_eq!(parse_reset_duration("5124095576030432h"), None);
+    }
+
+    #[test]
+    fn backpressure_keeps_later_deadline() {
+        let backpressure = ServerBackpressure::default();
+
+        backpressure.update_deadline(1_000);
+        backpressure.update_deadline(500);
+        assert_eq!(backpressure.reset_at_millis(), Some(1_000));
+
+        backpressure.update_deadline(2_000);
+        assert_eq!(backpressure.reset_at_millis(), Some(2_000));
+    }
+
+    #[test]
+    fn backpressure_clear_only_removes_observed_deadline() {
+        let backpressure = ServerBackpressure::default();
+
+        backpressure.update_deadline(1_000);
+        assert!(backpressure.clear_if_deadline(500).is_err());
+        assert_eq!(backpressure.reset_at_millis(), Some(1_000));
+
+        assert!(backpressure.clear_if_deadline(1_000).is_ok());
+        assert_eq!(backpressure.reset_at_millis(), None);
+    }
+
+    #[test]
+    fn update_backpressure_uses_reset_when_remaining_is_zero() {
+        let backpressure = ServerBackpressure::default();
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            crate::retry::X_RATELIMIT_REMAINING_REQUESTS,
+            reqwest::header::HeaderValue::from_static("0"),
+        );
+        headers.insert(
+            crate::retry::X_RATELIMIT_RESET_REQUESTS,
+            reqwest::header::HeaderValue::from_static("250ms"),
+        );
+
+        update_backpressure_from_headers(&headers, &backpressure, 1_000);
+
+        assert_eq!(backpressure.reset_at_millis(), Some(1_250));
+    }
+
+    #[test]
+    fn update_backpressure_ignores_nonzero_remaining() {
+        let backpressure = ServerBackpressure::default();
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            crate::retry::X_RATELIMIT_REMAINING_REQUESTS,
+            reqwest::header::HeaderValue::from_static("1"),
+        );
+        headers.insert(
+            crate::retry::X_RATELIMIT_RESET_REQUESTS,
+            reqwest::header::HeaderValue::from_static("1s"),
+        );
+
+        update_backpressure_from_headers(&headers, &backpressure, 1_000);
+
+        assert_eq!(backpressure.reset_at_millis(), None);
+    }
+
+    #[test]
+    fn update_backpressure_ignores_missing_or_invalid_remaining() {
+        let backpressure = ServerBackpressure::default();
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            crate::retry::X_RATELIMIT_RESET_REQUESTS,
+            reqwest::header::HeaderValue::from_static("1s"),
+        );
+
+        update_backpressure_from_headers(&headers, &backpressure, 1_000);
+        assert_eq!(backpressure.reset_at_millis(), None);
+
+        headers.insert(
+            crate::retry::X_RATELIMIT_REMAINING_REQUESTS,
+            reqwest::header::HeaderValue::from_static("not-a-number"),
+        );
+
+        update_backpressure_from_headers(&headers, &backpressure, 1_000);
+        assert_eq!(backpressure.reset_at_millis(), None);
+    }
+
+    #[test]
+    fn update_backpressure_ignores_missing_or_invalid_reset() {
+        let backpressure = ServerBackpressure::default();
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            crate::retry::X_RATELIMIT_REMAINING_REQUESTS,
+            reqwest::header::HeaderValue::from_static("0"),
+        );
+
+        update_backpressure_from_headers(&headers, &backpressure, 1_000);
+        assert_eq!(backpressure.reset_at_millis(), None);
+
+        headers.insert(
+            crate::retry::X_RATELIMIT_RESET_REQUESTS,
+            reqwest::header::HeaderValue::from_static("later"),
+        );
+
+        update_backpressure_from_headers(&headers, &backpressure, 1_000);
+        assert_eq!(backpressure.reset_at_millis(), None);
+    }
+
+    #[test]
+    fn update_backpressure_keeps_later_existing_deadline() {
+        let backpressure = ServerBackpressure::default();
+        backpressure.update_deadline(5_000);
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            crate::retry::X_RATELIMIT_REMAINING_REQUESTS,
+            reqwest::header::HeaderValue::from_static("0"),
+        );
+        headers.insert(
+            crate::retry::X_RATELIMIT_RESET_REQUESTS,
+            reqwest::header::HeaderValue::from_static("250ms"),
+        );
+
+        update_backpressure_from_headers(&headers, &backpressure, 1_000);
+
+        assert_eq!(backpressure.reset_at_millis(), Some(5_000));
+    }
+}

--- a/docs/superpowers/specs/2026-06-06-ratelimit-design.md
+++ b/docs/superpowers/specs/2026-06-06-ratelimit-design.md
@@ -1,0 +1,237 @@
+# RateLimitLayer Design
+
+## Overview
+
+A Tower middleware layer that provides client-side RPM (Requests Per Minute) rate limiting using a leaky bucket algorithm (GCRA via the `governor` crate), combined with server-side feedback backpressure using OpenAI's `x-ratelimit-*` response headers.
+
+## Motivation
+
+The current rate limit handling in async-openai relies on exponential backoff after receiving 429 responses. This is reactive - requests are sent first, then retried when rejected. For large batches, this wastes requests and time. A proactive approach using a local rate limiter prevents exceeding limits in the first place, while server-side header feedback adapts to actual tier limits when users configure RPM higher than their tier allows.
+
+## Goals
+
+- Proactive RPM limiting using governor (GCRA / leaky bucket)
+- Server-side backpressure via `x-ratelimit-remaining-requests` and `x-ratelimit-reset-requests` headers
+- Compatible with WASM targets
+- Zero impact on users who don't use it (optional middleware, gated behind `rate-limit` feature)
+- Works correctly under tower's clone-based service model
+
+## Non-Goals
+
+- TPM (Tokens Per Minute) limiting - requires extracting token usage from response bodies, separate design needed
+- Per-model keyed limits - users can compose at the application layer with one client per model
+- Precise governor bucket sync from `remaining-requests` - backpressure is sufficient for v1
+
+## Public API
+
+```rust
+use async_openai::middleware::rate_limit::RateLimitLayer;
+use async_openai::middleware::{ReqwestService, retry::OpenAIRetryLayer};
+
+let service = tower::ServiceBuilder::new()
+    .layer(OpenAIRetryLayer::default())
+    .layer(RateLimitLayer::per_minute(60))
+    .service(ReqwestService::new(reqwest::Client::new()));
+
+let client = Client::with_config(OpenAIConfig::default())
+    .with_http_service(service);
+```
+
+Single constructor: `RateLimitLayer::per_minute(rpm: u32)`. Header sync and backpressure are automatic.
+
+## Middleware Stack Position
+
+```
+HttpRequestFactory
+       |
+       v
+  OpenAIRetryLayer        <- retries on 429/5xx with exponential backoff
+       |
+       v
+  RateLimitLayer          <- proactive limiting + server-side backpressure
+       |
+       v
+  ReqwestService          <- actual HTTP transport
+```
+
+RateLimitLayer sits below OpenAIRetryLayer so that retries also go through rate limiting. Without this ordering, retries could bypass the limiter and exceed the configured RPM.
+
+## Request Flow
+
+1. Request arrives at retry layer, which calls down to rate limit layer
+2. `RateLimitService::poll_ready` checks two conditions:
+   - Governor local bucket has a token available
+   - `ServerBackpressure` reset time has passed (or is not set)
+   - If either condition fails, returns `Pending` - request stalls here
+3. When `poll_ready` returns `Ready`, `call` forwards the request to the inner service
+4. Response future intercepts the response, parses rate limit headers, updates `ServerBackpressure`
+
+## Retry Flow
+
+When a 429 is received, the retry layer backs off and retries. On retry, it calls `poll_ready` on the rate limit layer again. If the local bucket is empty or server backpressure is active, the retry is also throttled. Retries cannot bypass the limiter.
+
+## Internal Components
+
+### RateLimitLayer / RateLimitService
+
+```rust
+pub struct RateLimitLayer {
+    limiter: RateLimiter<NotKeyed, InMemoryState, QuantaInstant>,
+    backpressure: Arc<ServerBackpressure>,
+}
+
+pub struct RateLimitService<S> {
+    inner: S,
+    limiter: RateLimiter<NotKeyed, InMemoryState, QuantaInstant>,
+    backpressure: Arc<ServerBackpressure>,
+}
+```
+
+Governor's `RateLimiter` is `Clone` and internally uses `Arc` for state sharing, so all cloned `RateLimitService` instances share the same bucket.
+
+### ServerBackpressure
+
+```rust
+struct ServerBackpressure {
+    reset_at: AtomicU64,  // UNIX timestamp in milliseconds, 0 = no limit
+}
+```
+
+Uses `AtomicU64` instead of `Mutex` because:
+- Single writer: response future updating from headers
+- Single reader: `poll_ready` checking the timestamp
+- No multi-field atomic updates needed
+- Reset timestamp is `now + parse(reset_duration_string)`, stored as millis u64
+
+### Header Parsing and State Update
+
+In `call`, the returned future is wrapped to intercept the response:
+
+```rust
+fn call(&mut self, req: HttpRequestFactory) -> Self::Future {
+    let bp = self.backpressure.clone();
+    let inner_future = self.inner.call(req);
+    Box::pin(async move {
+        let response = inner_future.await?;
+        update_backpressure_from_headers(response.headers(), &bp);
+        Ok(response)
+    })
+}
+```
+
+### poll_ready Backpressure Logic
+
+```rust
+fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+    // 1. Check server backpressure
+    let reset_ms = self.backpressure.reset_at.load(Ordering::Relaxed);
+    if reset_ms > 0 {
+        let now = now_millis();
+        if now < reset_ms {
+            // Register waker via tokio::time::sleep, return Pending
+            return Poll::Pending;
+        }
+        // Reset time passed, clear
+        self.backpressure.reset_at.store(0, Ordering::Relaxed);
+    }
+
+    // 2. Check governor local bucket
+    match self.limiter.check() {
+        Ok(_) => self.inner.poll_ready(cx),
+        Err(NotUntil(_)) => Poll::Pending,
+    }
+}
+```
+
+Waker registration: on native targets, `poll_ready` creates a `tokio::time::sleep_until` and polls it to register the waker. On WASM, server-side backpressure is not implemented - `poll_ready` skips the reset time check and always proceeds to the governor check. This is consistent with the retry module's WASM behavior (no delays on WASM). Governor's local bucket still works on WASM via its `wasm` feature, providing basic RPM limiting without server feedback.
+
+## Edge Cases
+
+### Header Parsing Failures
+
+- `x-ratelimit-remaining-requests` missing or unparseable: ignore, rely on local governor
+- `x-ratelimit-reset-requests` missing or unparseable: ignore
+- `remaining` present but not 0: no backpressure update, debug log only
+- Both headers present and `remaining == 0`: compute `now + parse(reset)`, store in `reset_at`
+
+### Reset Header Format
+
+OpenAI returns duration strings like `"6s"`, `"1m30s"`. A simple parser handles `"Ns"`, `"Nm"`, `"NmNs"` formats. Invalid input returns `None` and is ignored.
+
+### Governor Bucket Exhaustion
+
+- `limiter.check()` returns `Err(NotUntil(deadline))`: `poll_ready` returns `Pending` until deadline
+- Normal traffic: governor passes through with zero overhead
+
+### Concurrent Clones
+
+- Tower clones services during retry; all clones share the same governor bucket (governor internal Arc) and same `ServerBackpressure` (Arc)
+- One clone's response future updating `reset_at` is immediately visible to other clones' `poll_ready`
+- No race conditions: `AtomicU64` store/load is atomic
+
+### User RPM Much Higher Than Tier Limit
+
+- Local governor passes requests at configured RPM
+- Before server 429, response headers show `remaining` decreasing to 0
+- Backpressure engages, `poll_ready` stalls, subsequent requests wait until reset time
+- Server feedback automatically takes over
+
+### No Rate Limit Configured
+
+- No `RateLimitLayer` added = no impact on existing behavior
+- Zero-intrusive design
+
+### Tracing
+
+- Backpressure engaged (remaining hits 0): `tracing::warn!`
+- Backpressure released (reset time passed): `tracing::info!`
+- Governor bucket exhausted: `tracing::debug!`
+- Header parse failure: `tracing::debug!` (not warn, to avoid noise)
+
+## Feature Gate
+
+New `rate-limit` feature in Cargo.toml:
+
+```toml
+rate-limit = ["dep:governor", "middleware"]
+```
+
+governor dependency:
+
+```toml
+governor = { version = "0.8", optional = true }
+
+[target.wasm32-unknown-unknown.dependencies]
+governor = { version = "0.8", features = ["wasm"], optional = true }
+```
+
+## Testing
+
+### Unit Tests (no network)
+
+- Mock service returning responses with rate limit headers, verify `ServerBackpressure` state updates correctly
+- Verify `poll_ready` returns `Pending` when `remaining=0` and reset not yet reached
+- Verify `poll_ready` returns `Ready` after reset time passes
+- Verify governor bucket exhaustion returns `Pending`
+- Reset header parser: `"6s"` -> 6s, `"1m30s"` -> 90s, invalid -> None
+
+### Integration Tests (no real API)
+
+- Mock service counting requests, verify request count doesn't exceed configured RPM in a time window
+- Verify retry + rate limit combination: after 429, retries are also rate limited
+
+## File Structure
+
+```
+async-openai/src/middleware/
+  mod.rs                  <- update docs, add rate_limit module export
+  retry/                  <- existing, no changes
+  rate_limit/
+    mod.rs                <- RateLimitLayer, RateLimitService, ServerBackpressure
+```
+
+New files: `async-openai/src/middleware/rate_limit/mod.rs`
+
+Modified files:
+- `async-openai/Cargo.toml` - add `rate-limit` feature and `governor` dependency
+- `async-openai/src/middleware/mod.rs` - export `rate_limit` module, update docs


### PR DESCRIPTION
接着 #320 的讨论，我把 RPM 限流层做了出来。

放在 retry 下面，governor 做 RPM 限流，同时从 x-ratelimit-remaining-requests 和 x-ratelimit-reset-requests 头读服务端的限流状态。remaining 到 0 的时候 poll_ready 会卡住等到 reset 时间再放行，避免发多余的请求。governor 桶和背压状态在 clone 之间共享，retry 的时候也走同一个桶。

native 上用 tokio::sleep 做等待，sleep future 存在 service 里防止 waker 丢掉；wasm 上只走 governor 本地计数，不做延迟。

TPM 限流需要从响应体提取 token 用量，后面单独做。

开了 rate-limit feature 才生效，不影响现有用户。13 个单测覆盖了 header 解析、背压状态、waker 注册、governor 桶共享、重试穿过限流层这些情况。