### PR TITLE
[codex] Add max reasoning effort

### DIFF
--- a/async-openai/src/types/shared/reasoning_effort.rs
+++ b/async-openai/src/types/shared/reasoning_effort.rs
@@ -10,4 +10,5 @@ pub enum ReasoningEffort {
     Medium,
     High,
     Xhigh,
+    Max,
 }


### PR DESCRIPTION
## Summary

Adds `ReasoningEffort::Max`, serializing to the OpenAI wire value `"max"` through the existing lowercase serde rule.

This lets typed request builders represent the `max` reasoning effort now shown for GPT-5.6 models in the OpenAI model catalog. The enum is shared across Chat, Responses, Evals, and Graders, so the variant is available wherever `ReasoningEffort` is reused.

## Validation

- `cargo test -p async-openai --features chat-completion-types --test ser_de`
- `cargo check -p async-openai --features responses`