### PR TITLE
fix(responses): make WebSearchActionFind.url optional

### DIFF
--- a/async-openai/src/types/responses/response.rs
+++ b/async-openai/src/types/responses/response.rs
@@ -2001,8 +2001,11 @@ pub struct WebSearchActionOpenPage {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct WebSearchActionFind {
-    /// The URL of the page searched for the pattern.
-    pub url: String,
+    /// The URL of the page searched for the pattern. Optional: the API omits it
+    /// for `find` / `find_in_page` actions that continue within a page already
+    /// opened by a prior `open_page` action. Mirrors the already-optional
+    /// `WebSearchActionOpenPage::url`.
+    pub url: Option<String>,
     /// The pattern or text to search for within the page.
     pub pattern: String,
 }


### PR DESCRIPTION
The Responses API omits `url` on `find` / `find_in_page` web-search actions that continue within a page already opened by a prior `open_page` action. Because `WebSearchActionFind.url` is a required `String`, deserializing such a response fails with `missing field `url``, which aborts parsing of the entire response for any web search that uses find-in-page continuation.

Make `url` an `Option<String>`, mirroring the already-optional `WebSearchActionOpenPage::url`. No other code constructs the struct and `cargo check` passes.