### PR TITLE
fix: accept on_demand chat service tier

### DIFF
--- a/async-openai/src/types/chat/chat_.rs
+++ b/async-openai/src/types/chat/chat_.rs
@@ -655,6 +655,8 @@ pub enum ServiceTier {
     Flex,
     Scale,
     Priority,
+    #[serde(rename = "on_demand")]
+    OnDemand,
 }
 
 /// Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are `low`, `medium`, and `high`.

--- a/async-openai/tests/ser_de.rs
+++ b/async-openai/tests/ser_de.rs
@@ -1,7 +1,7 @@
 use async_openai::types::chat::{
     ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs,
     ChatCompletionStreamOptions, CreateChatCompletionRequest, CreateChatCompletionRequestArgs,
-    FunctionCallStream,
+    FunctionCallStream, ServiceTier,
 };
 
 #[test]
@@ -26,6 +26,12 @@ fn chat_types_serde() {
     // deserialize the request
     let deserialized: CreateChatCompletionRequest = serde_json::from_str(&serialized).unwrap();
     assert_eq!(request, deserialized);
+}
+
+#[test]
+fn service_tier_accepts_groq_on_demand() {
+    let tier: ServiceTier = serde_json::from_str("\"on_demand\"").unwrap();
+    assert_eq!(serde_json::to_string(&tier).unwrap(), "\"on_demand\"");
 }
 
 #[test]


### PR DESCRIPTION
Groq may return service_tier on_demand in otherwise valid Chat Completions responses. This adds the compatible variant and a serde regression test.