### PR TITLE
feat: support max reasoning effort

### DIFF
--- a/async-openai/src/types/shared/reasoning_effort.rs
+++ b/async-openai/src/types/shared/reasoning_effort.rs
@@ -10,4 +10,18 @@ pub enum ReasoningEffort {
     Medium,
     High,
     Xhigh,
+    Max,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReasoningEffort;
+
+    #[test]
+    fn max_round_trips_through_json() {
+        let effort: ReasoningEffort = serde_json::from_str("\"max\"").unwrap();
+
+        assert_eq!(effort, ReasoningEffort::Max);
+        assert_eq!(serde_json::to_string(&effort).unwrap(), "\"max\"");
+    }
 }

--- a/async-openai/src/types/shared/reasoning_effort.rs
+++ b/async-openai/src/types/shared/reasoning_effort.rs
@@ -12,16 +12,3 @@ pub enum ReasoningEffort {
     Xhigh,
     Max,
 }
-
-#[cfg(test)]
-mod tests {
-    use super::ReasoningEffort;
-
-    #[test]
-    fn max_round_trips_through_json() {
-        let effort: ReasoningEffort = serde_json::from_str("\"max\"").unwrap();
-
-        assert_eq!(effort, ReasoningEffort::Max);
-        assert_eq!(serde_json::to_string(&effort).unwrap(), "\"max\"");
-    }
-}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -66281,6 +66281,7 @@ components:
             - medium
             - high
             - xhigh
+            - max
           default: medium
           description: >
             Constrains effort on reasoning for
@@ -66289,7 +66290,7 @@ components:
             models](https://platform.openai.com/docs/guides/reasoning).
 
             Currently supported values are `none`, `minimal`, `low`, `medium`,
-            `high`, and `xhigh`. Reducing
+            `high`, `xhigh`, and `max`. Reducing
 
             reasoning effort can result in faster responses and fewer tokens
             used


### PR DESCRIPTION
## Summary

- add the `Max` variant to the shared `ReasoningEffort` enum
- update the checked-in OpenAPI schema to include `max`

## Motivation

The official OpenAI Python API includes `"max"` as a supported reasoning effort value: [reasoning_effort.py](https://github.com/openai/openai-python/blob/7a3d5e46b61cb36109dc4e7fd6d4ab70cc6d6c0f/src/openai/types/shared/reasoning_effort.py#L8).

Without this variant, requests containing `reasoning.effort = "max"` fail to deserialize.

## Validation

- `cargo +1.96.1 check -p async-openai --features response-types`
- `cargo +1.96.1 check --workspace --all-features --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`